### PR TITLE
Add version of GFqDom() used by Macaulay2.

### DIFF
--- a/src/kernel/field/gfq.h
+++ b/src/kernel/field/gfq.h
@@ -98,6 +98,8 @@ public:
     template<typename Vector>
     GFqDom(const UTT P, const UTT e, const Vector& modPoly);
 
+    GFqDom( const UTT P, const UTT e, const std::vector<UTT>& modPoly, const std::vector<UTT>& generatorPoly);
+
     GFqDom( const GFqDom<TT>& F)
             : zero(F.zero),
               one(F.one),

--- a/src/kernel/field/gfq.inl
+++ b/src/kernel/field/gfq.inl
@@ -1047,6 +1047,77 @@ namespace Givaro {
         _plus1[(UT)mOne] = 0;
     }
 
+template<typename TT>
+    inline GFqDom<TT>::GFqDom(const UTT P, const UTT e, const std::vector<UTT>& modPoly, const std::vector<UTT>& generatorPol):
+            zero(0)
+        , one (power(P,e) - 1  )
+        , _characteristic(P)
+        , _exponent(e)
+        , _q( one + 1 )
+        , _qm1 ( one )
+        , _qm1o2(  (P==2)?  (one)  :  (_q >> 1) )   // 1 == -1 in GF(2^k)
+        , _log2pol( _q )
+        , _pol2log( _q )
+        , _plus1( _q )
+        , _dcharacteristic( (double)P )
+    {
+
+            // 1 is represented by q-1, zero by 0
+        _log2pol[0] = zero;
+
+        GFqDom<TT> Zp(P,1);
+        typedef Poly1FactorDom< GFqDom<TT>, Dense > PolDom;
+        PolDom Pdom( Zp );
+        typename PolDom::Element Ft, F(e+1), G(e), H;
+
+        for( size_t i = 0; i < F.size(); ++i )
+            Zp.init( F[i], modPoly[i]);
+
+        for( size_t i = 0; i < G.size(); ++i )
+        {
+            if (i <  generatorPol.size() )
+            {   Zp.init( G[i], generatorPol[i]); //std::cerr << " generatorPol[" << i << "]" << generatorPol[i] << std::endl;}
+            } else
+            {    Zp.init( G[i], 0 ); //std::cerr << " generatorPol[" << i << "]" << generatorPol[i] << std::endl; }
+        }}
+
+        //Pdom.give_prim_root(G,F);
+        Pdom.assign(H,G);
+
+        typedef Poly1PadicDom< GFqDom<TT>, Dense > PadicDom;
+        PadicDom PAD(Pdom);
+
+        PAD.eval(_log2pol[1],H);
+        PAD.eval(_irred, F);
+
+        for (UTT i = 2; i < _qm1; ++i) {
+            Pdom.mulin(H, G);
+            Pdom.modin(H, F);
+            PAD.eval(_log2pol[i], H);
+        }
+        _log2pol[_qm1] = 1;
+
+        _log2pol[0] = 0;
+
+        for (UTT i = 0; i < _q; ++i)
+            _pol2log[ _log2pol[i] ] = i;
+
+        _plus1[0] = 0;
+
+        UTT a,b,r;
+        for (UTT i = 1; i < _q; ++i) {
+            a = _log2pol[i];
+            r = a % P;
+            if (r == (P - 1))
+                b = a - r;
+            else
+                b = a + 1;
+            _plus1[i] = _pol2log[b] - _qm1;
+        }
+
+        _plus1[_qm1o2] = 0;
+    }
+
         // Dan Roche 6-15-04, adapted my/ported back to Givaro
         // by Martin Albrecht 10-06-06
         // This constructor takes a vector of ints that represent the polynomial


### PR DESCRIPTION
Macaulay2 uses givaro as a dependency.  However, it builds its own patched
givaro, adding an additional version of the function GFqDom [1].  It would
great if this function existed natively so that Macaulay2 could be built
using a pre-existing givaro on the user's system.

[1] https://github.com/Macaulay2/M2/blob/master/M2/libraries/givaro/patch-3.7.0