### PR TITLE
Fix several problems in the build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,12 +48,15 @@ DISTCLEANFILES = src/kernel/system/givaro   \
 		 src/kernel/rational/givaro \
 		 src/kernel/recint/recint   \
 		 src/kernel/field/givaro    \
-		 src/kernel/ring/givaro    \
+		 src/kernel/ring/givaro     \
 		 src/kernel/gmp++/gmp++     \
 		 src/library/matrix/givaro  \
 		 src/library/poly1/givaro   \
 		 src/library/tools/givaro   \
-		 src/library/vector/givaro
+		 src/library/vector/givaro  \
+		 givaro-config.h            \
+		 docs/DoxyfileDev	    \
+		 docs/Doxyfile
 
 uninstall-hook:
 	(test -d "$(includedir)/givaro" && rmdir "$(includedir)/givaro") || true

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -7,7 +7,7 @@
 SUBDIRS =
 benchmarks: $(EXTRA_PROGRAMS)
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 PERFPUBLISHERFILE=benchmarks-report.xml
 
@@ -15,7 +15,7 @@ OPTFLAGS=
 OPTLINKS=
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CXXFLAGS += $(OPTFLAGS)  -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/recint -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel/gmp++ -I$(top_srcdir)/src/kernel/ring $(GMP_CFLAGS)
+AM_CXXFLAGS += $(OPTFLAGS)  -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/recint -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel/gmp++ -I$(top_builddir)/src/kernel/ring $(GMP_CFLAGS)
 
 LDADD = $(OPTLINKS) $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -17,7 +17,7 @@ OPTLINKS=
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CXXFLAGS += $(OPTFLAGS)  -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/recint -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel/gmp++ -I$(top_srcdir)/src/kernel/ring $(GMP_CFLAGS)
 
-LDADD = $(OPTLINKS) -L${top_srcdir}/src -L${top_srcdir}/src/.libs -lgivaro $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(OPTLINKS) $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 BENCHMARKS=				\

--- a/configure.ac
+++ b/configure.ac
@@ -224,7 +224,6 @@ echo "-----------------------------------------------"
 
 echo "-----------------------------------------------"
 
-DEFAULT_CHECKING_PATH="/usr /usr/local /opt/local"  
 GIV_CHECK_GMP(40000)
 
 GIV_DOC

--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,6 @@ echo "-----------------------------------------------"
 
 AC_CONFIG_FILES([
 Makefile
-givaro-config
 givaro-makefile
 src/Makefile
 src/kernel/Makefile
@@ -274,7 +273,8 @@ examples/Polynomial/Makefile
 tests/Makefile
 docs/Makefile
 givaro.pc
-],[chmod +x givaro-config])
+])
+AC_CONFIG_FILES([givaro-config],[chmod +x givaro-config])
 AC_OUTPUT
 
 echo "-----------------------------------------------"

--- a/configure.ac
+++ b/configure.ac
@@ -196,22 +196,28 @@ AC_C_BIGENDIAN(
   [AC_DEFINE(HAVE_LITTLE_ENDIAN, 1, [Define that architecture uses little endian storage])],
   [])
 
-echo "Creating symbolic link for compilation"
-if test ! -L src/kernel/system/givaro  ; then ln -s . src/kernel/system/givaro  ; fi
-if test ! -L src/kernel/bstruct/givaro ; then ln -s . src/kernel/bstruct/givaro ; fi
-if test ! -L src/kernel/integer/givaro ; then ln -s . src/kernel/integer/givaro ; fi
-if test ! -L src/kernel/memory/givaro  ; then ln -s . src/kernel/memory/givaro  ; fi
-if test ! -L src/kernel/rational/givaro; then ln -s . src/kernel/rational/givaro; fi
-if test ! -L src/kernel/recint/recint  ; then ln -s . src/kernel/recint/recint;   fi
-if test ! -L src/kernel/field/givaro   ; then ln -s . src/kernel/field/givaro;    fi
-if test ! -L src/kernel/ring/givaro    ; then ln -s . src/kernel/ring/givaro;    fi
-if test ! -L src/kernel/gmp++/gmp++    ; then ln -s . src/kernel/gmp++/gmp++    ; fi
-if test ! -L src/library/matrix/givaro ; then ln -s . src/library/matrix/givaro ; fi
-if test ! -L src/library/poly1/givaro  ; then ln -s . src/library/poly1/givaro  ; fi
-if test ! -L src/library/tools/givaro  ; then ln -s . src/library/tools/givaro  ; fi
-if test ! -L src/library/vector/givaro ; then ln -s . src/library/vector/givaro ; fi
+AC_MSG_NOTICE([Creating symbolic link for compilation])
+for link in \
+	src/kernel/system/givaro   \
+	src/kernel/bstruct/givaro  \
+	src/kernel/integer/givaro  \
+	src/kernel/memory/givaro   \
+	src/kernel/rational/givaro \
+	src/kernel/recint/recint   \
+	src/kernel/field/givaro    \
+	src/kernel/ring/givaro     \
+	src/kernel/gmp++/gmp++     \
+	src/library/matrix/givaro  \
+	src/library/poly1/givaro   \
+	src/library/tools/givaro   \
+	src/library/vector/givaro  \
+	; do
 
-
+	dir="$(dirname "$link")"
+	AS_MKDIR_P([$dir])
+	AS_IF([ test ! -L "$link" ],
+	  [ln -s "../../../$srcdir/$dir" "$link"])
+done
 
 AC_DEFINE_UNQUOTED(INT8,  $GIVARO_INT8, Canonical 8-bit data type)
 AC_DEFINE_UNQUOTED(INT16, $GIVARO_INT16, Canonical 16-bit data type)

--- a/examples/FiniteField/Makefile.am
+++ b/examples/FiniteField/Makefile.am
@@ -5,7 +5,7 @@
 # see the COPYRIGHT file for more details.
 examples: $(EXTRA_PROGRAMS)
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 OPTFLAGS=
 OPTLINKS=
@@ -29,9 +29,9 @@ OPTLINKS=
 #OPTFLAGS+= -tpp2 -mcpu=itanium2
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS) -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/field -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/library/poly1 -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/library/tools
+AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS) -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/field -I$(top_builddir)/src/kernel/ring -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/library/poly1 -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/library/tools -I$(top_srcdir)/src/kernel
 
-LDADD = $(OPTLINKS) $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(OPTLINKS) $(top_builddir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/examples/FiniteField/Makefile.am
+++ b/examples/FiniteField/Makefile.am
@@ -31,7 +31,7 @@ OPTLINKS=
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS) -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/field -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/library/poly1 -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/library/tools
 
-LDADD = $(OPTLINKS) -L${top_srcdir}/src -L${top_srcdir}/src/.libs -lgivaro $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(OPTLINKS) $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/examples/Integer/Makefile.am
+++ b/examples/Integer/Makefile.am
@@ -27,7 +27,7 @@ AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS)
 AM_CPPFLAGS += -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/field -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/library/poly1 -I$(top_srcdir)/src/library/tools
 
-LDADD = -L${top_srcdir}/src -L${top_srcdir}/src/.libs -lgivaro $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 EXTRA_PROGRAMS=ifactor ifactor_lenstra igcd igcdext ilcm isproot nb_primes isprime nextprime order prevprime RSA_breaking RSA_keys_generator primitiveroot primitiveelement phi lambda lambda_inv iexponentiation RSA_decipher  RSA_encipher  ispower probable_primroot ProbLucas ModularSquareRoot

--- a/examples/Integer/Makefile.am
+++ b/examples/Integer/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 examples: $(EXTRA_PROGRAMS)
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 #OPTFLAGS = -O7 -funroll-all-loops -felide-constructors -fstrict-aliasing
 #OPTFLAGS+= -frerun-loop-opt -fexpensive-optimizations
@@ -25,9 +25,9 @@ AM_CPPFLAGS=-I$(top_srcdir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS)
-AM_CPPFLAGS += -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/field -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/library/poly1 -I$(top_srcdir)/src/library/tools
+AM_CPPFLAGS += -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/kernel/field -I$(top_builddir)/src/kernel/ring -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/library/poly1 -I$(top_builddir)/src/library/tools -I$(top_srcdir)/src/kernel
 
-LDADD = $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(top_builddir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 EXTRA_PROGRAMS=ifactor ifactor_lenstra igcd igcdext ilcm isproot nb_primes isprime nextprime order prevprime RSA_breaking RSA_keys_generator primitiveroot primitiveelement phi lambda lambda_inv iexponentiation RSA_decipher  RSA_encipher  ispower probable_primroot ProbLucas ModularSquareRoot

--- a/examples/Polynomial/Makefile.am
+++ b/examples/Polynomial/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 examples: $(EXTRA_PROGRAMS)
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 #OPTFLAGS = -O7 -funroll-all-loops -felide-constructors -fstrict-aliasing
 #OPTFLAGS+= -frerun-loop-opt -fexpensive-optimizations
@@ -24,9 +24,9 @@ AM_CPPFLAGS=-I$(top_srcdir)
 
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS) -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/library/poly1 -I$(top_srcdir)/src/kernel/field -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/kernel/rational -I$(top_srcdir)/src/library/tools
+AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS) -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/library/poly1 -I$(top_builddir)/src/kernel/field -I$(top_builddir)/src/kernel/ring -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/kernel/rational -I$(top_builddir)/src/library/tools -I$(top_srcdir)/src/kernel
 
-LDADD = $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(top_builddir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/examples/Polynomial/Makefile.am
+++ b/examples/Polynomial/Makefile.am
@@ -26,7 +26,7 @@ AM_CPPFLAGS=-I$(top_srcdir)
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS) -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/library/poly1 -I$(top_srcdir)/src/kernel/field -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/kernel/rational -I$(top_srcdir)/src/library/tools
 
-LDADD = -L${top_srcdir}/src -L${top_srcdir}/src/.libs -lgivaro $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/examples/Rational/Makefile.am
+++ b/examples/Rational/Makefile.am
@@ -27,7 +27,7 @@ AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS)
 AM_CPPFLAGS += -I$(top_srcdir)/src/kernel/system  -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/kernel/rational -I$(top_srcdir)/src/library/tools -I$(top_srcdir)/src/library/poly1
 
-LDADD = -L${top_srcdir}/src -L${top_srcdir}/src/.libs -lgivaro $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/examples/Rational/Makefile.am
+++ b/examples/Rational/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 examples: $(EXTRA_PROGRAMS)
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 #OPTFLAGS = -O7 -funroll-all-loops -felide-constructors -fstrict-aliasing
 #OPTFLAGS+= -frerun-loop-opt -fexpensive-optimizations
@@ -25,9 +25,9 @@ AM_CPPFLAGS=-I$(top_srcdir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS)
-AM_CPPFLAGS += -I$(top_srcdir)/src/kernel/system  -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/kernel/rational -I$(top_srcdir)/src/library/tools -I$(top_srcdir)/src/library/poly1
+AM_CPPFLAGS += -I$(top_builddir)/src/kernel/system  -I$(top_builddir)/src/kernel/ring -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/kernel/rational -I$(top_builddir)/src/library/tools -I$(top_builddir)/src/library/poly1 -I$(top_builddir)/src/kernel
 
-LDADD = $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(top_builddir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/examples/RecInt/Makefile.am
+++ b/examples/RecInt/Makefile.am
@@ -12,7 +12,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/kernel
 #OPTFLAGS=
 #OPTLINKS=
 
-LDADD = $(OPTLINKS) -L${top_srcdir}/src -L${top_srcdir}/src/.libs -lgivaro $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(OPTLINKS) $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/examples/RecInt/Makefile.am
+++ b/examples/RecInt/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 examples: $(EXTRA_PROGRAMS)
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS += $(OPTFLAGS) $(GMP_CFLAGS)
 AM_CPPFLAGS += -I$(top_srcdir)/src/kernel
@@ -12,7 +12,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/kernel
 #OPTFLAGS=
 #OPTLINKS=
 
-LDADD = $(OPTLINKS) $(top_srcdir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
+LDADD = $(OPTLINKS) $(top_builddir)/src/libgivaro.la $(GMP_LIBS) $(LDFLAGS)
 AM_LDFLAGS=-static
 
 

--- a/macros/givaro-doc.m4
+++ b/macros/givaro-doc.m4
@@ -30,7 +30,7 @@ AC_SUBST(GIVARO_DOC_PATH)
 AC_ARG_WITH(doxygen,
 [AC_HELP_STRING([--with-doxygen=<path>], [Give the path to Doxygen. Note: --enable-doc needed])],
             [
-		DOXYGEN_PATH="$PATH $withval"
+		DOXYGEN_PATH="$PATH:$withval"
 	    ],
 	    [
 		DOXYGEN_PATH="$PATH"

--- a/macros/givaro-doc.m4
+++ b/macros/givaro-doc.m4
@@ -68,13 +68,14 @@ AC_MSG_CHECKING(whether dot works)
 res=yes;
 (dot -V) < /dev/null > /dev/null 2>&1 || res=no
 AC_MSG_RESULT([$res])
+AS_MKDIR_P([docs])
 AS_IF([test $res = yes],
 [
-sed 's/^HAVE_DOT.*/HAVE_DOT = YES/' docs/Doxyfile.mod > docs/Doxyfile
-sed 's/^HAVE_DOT.*/HAVE_DOT = YES/' docs/DoxyfileDev.mod > docs/DoxyfileDev
+sed 's/^HAVE_DOT.*/HAVE_DOT = YES/' "$srcdir"/docs/Doxyfile.mod > docs/Doxyfile
+sed 's/^HAVE_DOT.*/HAVE_DOT = YES/' "$srcdir"/docs/DoxyfileDev.mod > docs/DoxyfileDev
 ],
-[ cp docs/Doxyfile.mod docs/Doxyfile ;
-cp docs/DoxyfileDev.mod docs/DoxyfileDev
+[ cp "$srcdir"/docs/Doxyfile.mod docs/Doxyfile ;
+cp "$srcdir"/docs/DoxyfileDev.mod docs/DoxyfileDev
 ])
 
 

--- a/macros/gmp-check.m4
+++ b/macros/gmp-check.m4
@@ -16,16 +16,20 @@ AC_DEFUN([GIV_CHECK_GMP], [
 	min_gmp_release=$1
 
 	########## ./configure parameter
+	_ac_gmp_use=yes
 	AC_ARG_WITH(gmp, 
 		[AC_HELP_STRING(
 			[--with-gmp=<path>], 
 			[Path to the GMP library. If unspecified, that means the library is reachable 
-			 with the standard search path (/usr or /usr/local).]
+			 with the standard search path of the current compiler.]
 		) ],
-		[ if test "$withval" != ""; then
-			GMP_HOME_PATH="$withval"
-		  fi ],
-		[GMP_HOME_PATH=${DEFAULT_CHECKING_PATH}]
+		[ AS_CASE(["x$withval"],
+		    [x],    [GMP_HOME_PATH= ],
+		    [xyes], [GMP_HOME_PATH= ],
+		    [xno],  [_ac_gmp_use=no],
+		    [GMP_HOME_PATH="$withval"])
+		],
+		[GMP_HOME_PATH=]
 	)
 
 	######### Check for existence
@@ -33,38 +37,35 @@ AC_DEFUN([GIV_CHECK_GMP], [
 	BACKUP_CXXFLAGS=${CXXFLAGS}
 	BACKUP_LIBS=${LIBS}
 
-	AC_MSG_CHECKING(for GMP)
+	GMP_CFLAGS=
+	GMP_LIBS=
+	AS_IF([ test "x$GMP_HOME" != "x" ], [
+		GMP_CFLAGS="-I${GMP_HOME}/include"
+		GMP_LIBS="-L${GMP_HOME}/lib"
+	])
+	GMP_LIBS="$GMP_LIBS -lgmp"
 
-	for GMP_HOME in ${GMP_HOME_PATH}
-	do
-		if test -r "$GMP_HOME/include/gmp.h"; then
-
-			if test "x$GMP_HOME" != "x/usr"; then
-				GMP_CFLAGS="-I${GMP_HOME}/include"
-				GMP_LIBS="-L${GMP_HOME}/lib"
-			fi
-			GMP_LIBS="$GMP_LIBS -lgmp"
-			
-
-			######### try to compile
-			CXXFLAGS="${BACKUP_CFLAGS} ${GMP_CFLAGS}"
-			LIBS="${BACKUP_LIBS} ${GMP_LIBS}"
-			AC_LINK_IFELSE(
-				[ 
-					AC_LANG_PROGRAM(
-						[[#include <gmp.h>]], 
-						[[ mpz_t a; mpz_init (a); ]] )
-				],
-				[ 
-					gmp_found="yes"
-				 	break # exit the loop
-				],
-				[ gmp_found="no (gmp.h found but linking failed)" ]
-			)
-		else
-	    		gmp_found="no (gmp.h not found)"
-		fi
-	done
+	######### try to compile
+	CXXFLAGS="${BACKUP_CFLAGS} ${GMP_CFLAGS}"
+	LIBS="${BACKUP_LIBS} ${GMP_LIBS}"
+	AC_LANG_PUSH([C++])
+	AC_CHECK_HEADER([gmp.h], [
+		AC_MSG_CHECKING(for GMP library)
+		AC_LINK_IFELSE(
+			[
+				AC_LANG_PROGRAM(
+					[[#include <gmp.h>]],
+					[[ mpz_t a; mpz_init (a); ]] )
+			],
+			[
+				gmp_found="yes"
+			],
+			[ gmp_found="no (gmp.h found but linking failed)" ]
+		)
+	], [
+		gmp_found="no (gmp.h not found)"
+	])
+	AC_LANG_POP([C++])
 
 	AC_MSG_RESULT(${gmp_found})
 
@@ -75,17 +76,25 @@ AC_DEFUN([GIV_CHECK_GMP], [
 
 	##### OK, we have found a working GMP. Check if it has c++ bindings, and is recent enough
 	
-	AC_MSG_CHECKING(for GMP version and cxx support)
 	GMP_LIBS="$GMP_LIBS -lgmpxx"
-	AC_LINK_IFELSE( 
-		[ AC_LANG_PROGRAM(
-			[[ #include <gmpxx.h> ]],
-			[[ mpz_class a(2), b(3), c(5); ]]
-		) ],
-		,
-		[ AC_MSG_ERROR(your GMP does not have c++ support. Compile GMP with --enable-cxx)]
-	)
+	AC_CHECK_HEADER([gmpxx.h], [
+		dnl AC_MSG_CHECKING(for GMP version and cxx support)
+		AC_MSG_CHECKING(for GMP cxx support)
+		AC_LINK_IFELSE(
+			[ AC_LANG_PROGRAM(
+				[[ #include <gmpxx.h> ]],
+				[[ mpz_class a(2), b(3), c(5); ]]
+			) ],
+			[ AC_MSG_RESULT(yes)
+			],
+			[ AC_MSG_RESULT(no)
+			  AC_MSG_ERROR(your GMP does not have c++ support. Compile GMP with --enable-cxx)]
+		)
+	], [
+		AC_MSG_RESULT(no)
+	])
 
+	AC_MSG_CHECKING([whether gmp version is at least $min_gmp_release])
 	AC_TRY_RUN(
 		[ 
 			#include <gmp.h>
@@ -93,11 +102,12 @@ AC_DEFUN([GIV_CHECK_GMP], [
 				return (__GNU_MP_RELEASE < $min_gmp_release);
 			}
 		],
-		,
-		[AC_MSG_ERROR(your GMP is too old. GMP release >= $min_gmp_release needed)]
+		[ AC_MSG_RESULT(yes)
+		],
+		[ AC_MSG_RESULT(no)
+		  AC_MSG_ERROR(your GMP is too old. GMP release >= $min_gmp_release needed)]
 	)
 	
-	AC_MSG_RESULT(OK)
 	AC_SUBST(GMP_CFLAGS)
 	AC_SUBST(GMP_LIBS)
 	AC_DEFINE(HAVE_GMP, 1 ,[Define if GMP is installed and OK])

--- a/src/kernel/Makefile.am
+++ b/src/kernel/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 

--- a/src/kernel/bstruct/Makefile.am
+++ b/src/kernel/bstruct/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory
 
 pkginclude_HEADERS=     \
 	givarray0.h		    \

--- a/src/kernel/field/Makefile.am
+++ b/src/kernel/field/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)  ${GMP_VERSION}
+AM_CPPFLAGS=-I$(top_builddir)  ${GMP_VERSION}
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/bstruct
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/bstruct
 
 pkginclude_HEADERS=     \
 	StaticElement.h		\

--- a/src/kernel/gmp++/Makefile.am
+++ b/src/kernel/gmp++/Makefile.am
@@ -4,12 +4,12 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir) ${GMP_VERSION}
+AM_CPPFLAGS=-I$(top_builddir) ${GMP_VERSION}
 
 pkgincludesubdir=$(includedir)/gmp++
 
 AM_CXXFLAGS=@DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/recint
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/recint
 
 
 noinst_LTLIBRARIES=libgmppp.la

--- a/src/kernel/integer/Makefile.am
+++ b/src/kernel/integer/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)  ${GMP_VERSION}
+AM_CPPFLAGS=-I$(top_builddir)  ${GMP_VERSION}
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/memory  -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/ring
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/memory  -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel -I$(top_builddir)/src/kernel/ring -I$(top_srcdir)/src/kernel
 
 pkginclude_HEADERS=         \
 	givinteger.h		    \

--- a/src/kernel/memory/Makefile.am
+++ b/src/kernel/memory/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS=@DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/system
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/system
 
 pkginclude_HEADERS= \
 	givaromm.h     	\

--- a/src/kernel/rational/Makefile.am
+++ b/src/kernel/rational/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)  ${GMP_VERSION}
+AM_CPPFLAGS=-I$(top_builddir)  ${GMP_VERSION}
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/ring
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/ring -I$(top_srcdir)/src/kernel
 
 pkginclude_HEADERS= \
 	givrational.h	\

--- a/src/kernel/recint/Makefile.am
+++ b/src/kernel/recint/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 pkgincludesubdir=$(includedir)/recint
 

--- a/src/kernel/ring/Makefile.am
+++ b/src/kernel/ring/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)  ${GMP_VERSION}
+AM_CPPFLAGS=-I$(top_builddir)  ${GMP_VERSION}
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/bstruct
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/bstruct
 
 pkginclude_HEADERS=     \
 	modular.h		    \

--- a/src/kernel/system/Makefile.am
+++ b/src/kernel/system/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS=@DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/memory
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/memory
 
 pkginclude_HEADERS= \
 	givbasictype.h	\

--- a/src/library/Makefile.am
+++ b/src/library/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 SUBDIRS=poly1 tools vector matrix
 

--- a/src/library/matrix/Makefile.am
+++ b/src/library/matrix/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/library/vector
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/library/vector
 
 pkginclude_HEADERS=         \
 	givmatdense.h		    \

--- a/src/library/poly1/Makefile.am
+++ b/src/library/poly1/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory
 
 pkginclude_HEADERS=        \
 	givindeter.h		   \

--- a/src/library/tools/Makefile.am
+++ b/src/library/tools/Makefile.am
@@ -4,7 +4,7 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
 AM_CPPFLAGS+= -I$(prefix)/include

--- a/src/library/vector/Makefile.am
+++ b/src/library/vector/Makefile.am
@@ -4,10 +4,10 @@
 # and abiding by the rules of distribution of free software.
 # see the COPYRIGHT file for more details.
 
-AM_CPPFLAGS=-I$(top_srcdir)
+AM_CPPFLAGS=-I$(top_builddir)
 
 AM_CXXFLAGS = @DEFAULT_CFLAGS@
-AM_CPPFLAGS+= -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory
 
 pkginclude_HEADERS=     \
 	givstorage.h		\

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,7 @@ check: $(BASE_TESTS)
 OPTFLAGS= -DSTD_RECINT_SIZE=8
 OPTLINKS=
 
-AM_CXXFLAGS = @TESTS_CFLAGS@ $(OPTFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src/kernel/system -I$(top_srcdir)/src/kernel/memory -I$(top_srcdir)/src/kernel/field -I$(top_srcdir)/src/kernel/ring -I$(top_srcdir)/src/kernel/integer -I$(top_srcdir)/src/kernel -I$(top_srcdir)/src/library/poly1 -I$(top_srcdir)/src/kernel/bstruct -I$(top_srcdir)/src/library/tools -I$(top_srcdir)/src/kernel/recint $(GMP_CFLAGS)
+AM_CXXFLAGS = @TESTS_CFLAGS@ $(OPTFLAGS) -I$(top_builddir) -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/field -I$(top_builddir)/src/kernel/ring -I$(top_builddir)/src/kernel/integer -I$(top_builddir)/src/kernel -I$(top_builddir)/src/library/poly1 -I$(top_builddir)/src/kernel/bstruct -I$(top_builddir)/src/library/tools -I$(top_builddir)/src/kernel/recint -I$(top_srcdir)/src/kernel $(GMP_CFLAGS)
 
 LDADD = $(OPTLINKS) ../src/libgivaro.la $(GMP_LIBS)
 AM_LDFLAGS=-static $(LDFLAGS)


### PR DESCRIPTION
These commits fix several flaw in the givaro build system. The main ones are:
* do not impose a system layout when using system directories (mainly gmp detection)
* do not mess with the source tree and the build tree
  If they are different, the source tree must be handled as if it were read-only
* use libtool artefacts (lib*.la) for project-internal linking

With all these commits, "make distcheck" is successful on my machine.

I did not look at the documentation generation. It is probable that it should be fixed when using a separate build tree.

Eventually, I'm a bit surprise of the forced static linking for benchmarks, examples and tests. Perhaps the performance justify this, but it should probably be reevaluated with the recent compilers/linkers.

  Regards,
    Vincent