### PR TITLE
pkgconfig file must not have non -I flags

### DIFF
--- a/givaro.pc.in
+++ b/givaro.pc.in
@@ -10,5 +10,5 @@ URL: http://givaro.forge.imag.fr
 Version: @VERSION@
 Requires:
 Libs: -L@libdir@ -lgivaro @LIBS@
-Cflags: -I@includedir@ @CXXFLAGS@
+Cflags: -I@includedir@
 \-------------------------------------------------------


### PR DESCRIPTION
The Cflags directive in .pc files is really meant for the
preprocessor, not for the compiler. It must only contain -D and -I
flags. Otherwise, it forces flags on downstream programs that may not
want them.

In case of the build.opensuse.org build farm, it has even led to
crashes as the machine that was randomly selected to build givaro had
SSE4, emitting -msse4.1 into Cflags, while the machine randomly
selected to build fflas-ffpack had only SSE2. That cannot work.

```
Cflags: -I/usr/include  -fmessage-length=0 -grecord-gcc-switches -O2
-Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables
-fasynchronous-unwind-tables  -mmmx -mpopcnt -msse -msse2 -msse3
-msse4.1 -msse4.2 -msse4a -mavx -mfma -mfma4 -mbmi -mfpmath=sse
-fabi-version=6
```
---
I also thought about removing `@LIBS@`, since all the libraries givaro itself needs are already recorded in `libgivaro.so.9` and `libgivaro.la`. Then I saw that givaro uses inline functions which would force downstream packages need to know about givaro's inline use of e.g. gmp. The solution pkgconfig has at hand is to use the `Requires:` directive to request another .pc file (instead of splicing `@CXXFLAGS@`/`@LIBS@` like it it currently done).