### PR TITLE
Support for Modular<float,double>

### DIFF
--- a/src/kernel/ring/modular-floating.inl
+++ b/src/kernel/ring/modular-floating.inl
@@ -75,16 +75,16 @@ namespace Givaro {
     TMPL
     inline typename MOD::Element&  MOD::reduce (Element& x) const
     {
-        x = std::fmod(x, _pc);
-        if (x < 0) x += _pc;
+        x = std::fmod(x, Caster<Element>(_pc));
+        if (x < 0) x += Caster<Element>(_pc);
         return x;
     }
 
     TMPL
     inline typename MOD::Element&  MOD::reduce (Element& x, const Element& y) const
     {
-        x = std::fmod(y, _pc);
-        if (x < 0.f) x += _pc;
+        x = std::fmod(y, Caster<Element>(_pc));
+        if (x < 0.f) x += Caster<Element>(_pc);
         return x;
     }
 
@@ -95,22 +95,22 @@ namespace Givaro {
     inline typename MOD::Element & MOD::add
     (Element &x, const Element &y, const Element &z) const
     {
-        x = y + z;
-        return x = (x<_pc?x:x-_pc);
+        Compute_t tmp = Caster<Compute_t>(y) + Caster<Compute_t>(z);
+        return x = Caster<Element>(tmp<_pc?tmp:tmp-_pc);
     }
 
     TMPL
     inline typename MOD::Element & MOD::sub
     (Element &x, const Element &y, const Element &z) const
     {
-        return x = (y>=z)? y-z:(_pc-z)+y;
+        return x = (y>=z)? y-z:(Caster<Element>(_pc)-z)+y;
     }
 
     TMPL
     inline typename MOD::Element & MOD::mul
     (Element &x, const Element &y, const Element &z) const
     {
-        return x = std::fmod(y*z, _pc);
+        return x = Caster<Element>(std::fmod(Caster<Compute_t>(y)*Caster<Compute_t>(z), _pc));
     }
 
     TMPL
@@ -124,31 +124,30 @@ namespace Givaro {
     inline typename MOD::Element & MOD::neg
     (Element &x, const Element &y) const
     {
-        return x = (y==0?0:_pc-y);
+        return x = (y==Caster<Element>(0)?Caster<Element>(0):Caster<Element>(_pc)-y);
     }
 
     TMPL
     inline typename MOD::Element & MOD::inv
     (Element &x, const Element &y) const
     {
-        invext(x,y,Caster<Element>(_p));
-        return (x<0 ? x+=Caster<Element>(_p) : x);
-        return x;
-        }
+        invext(x,y,Caster<Element>(_pc));
+        return (x<Caster<Element>(0) ? x+=Caster<Element>(_pc) : x);
+    }
 
     TMPL
     inline typename MOD::Element & MOD::addin
     (Element &x, const Element &y) const
     {
-        x += y;
-        return x = (x<_pc?x:x-_pc);
+	Compute_t tmp = Caster<Compute_t>(x) + Caster<Compute_t>(y);
+        return x = Caster<Element>(tmp < _pc? tmp : tmp - _pc);
     }
 
     TMPL
     inline typename MOD::Element & MOD::subin
     (Element &x, const Element &y) const
     {
-        if (x<y) x += (_pc-y);
+        if (x<y) x += (Caster<Element>(_pc)-y);
         else     x -= y;
         return x;
     }
@@ -157,7 +156,7 @@ namespace Givaro {
     inline typename MOD::Element & MOD::mulin
     (Element &x, const Element &y) const
     {
-        return x = std::fmod(x*y, _pc);
+        return x = Caster<Element>(std::fmod(Caster<Compute_t>(x)*Caster<Compute_t>(y), _pc));
     }
 
     TMPL
@@ -172,7 +171,7 @@ namespace Givaro {
     inline typename MOD::Element & MOD::negin
     (Element &x) const
     {
-        return x = (x==0?0:_pc-x);
+        return x = (x==Caster<Element>(0)?Caster<Element>(0):Caster<Element>(_pc)-x);
     }
 
     TMPL
@@ -187,14 +186,14 @@ namespace Givaro {
     inline typename MOD::Element & MOD::axpy
     (Element &r, const Element &a, const Element &x, const Element &y) const
     {
-        return r = std::fmod(a*x+y, _pc);
+        return r = Caster<Element>(std::fmod(Caster<Compute_t>(a)*Caster<Compute_t>(x)+Caster<Compute_t>(y), _pc));
     }
 
     TMPL
     inline typename MOD::Element & MOD::axpyin
     (Element &r, const Element &a, const Element &x) const
     {
-        return r = std::fmod(a*x + r, _pc);
+        return r = Caster<Element>(std::fmod(Caster<Compute_t>(a)*Caster<Compute_t>(x)+Caster<Compute_t>(r), _pc));
     }
 
     // -- axmy: r <- a * x - y
@@ -202,7 +201,7 @@ namespace Givaro {
     inline typename MOD::Element & MOD::axmy
     (Element& r, const Element &a, const Element &x, const Element &y) const
     {
-        return r = std::fmod(a*x + (_pc-y), _pc);
+        return r = Caster<Element>(std::fmod(Caster<Compute_t>(a)*Caster<Compute_t>(x) + (_pc-Caster<Compute_t>(y)), _pc));
     }
 
     TMPL
@@ -218,8 +217,8 @@ namespace Givaro {
     inline typename MOD::Element&  MOD::maxpy
     (Element& r, const Element& a, const Element& x, const Element& y) const
     {
-        r = a*x + (_pc-y);
-        r = (r<_pc ? r : std::fmod(r,_pc));
+	r = Caster<Element>(std::fmod(Caster<Compute_t>(a) * Caster<Compute_t>(x)
+			+ (_pc - Caster<Compute_t>(y)), _pc));
         return negin(r);
     }
 
@@ -227,8 +226,8 @@ namespace Givaro {
     inline typename MOD::Element&  MOD::maxpyin
     (Element& r, const Element& a, const Element& x) const
     {
-        r = a*x + (_pc-r);
-        r = (r<_pc ? r : std::fmod(r,_pc));
+	Compute_t tmp = Caster<Compute_t>(a) * Caster<Compute_t>(x) + (_pc - Caster<Compute_t>(r));
+	r = (tmp < _pc) ? Caster<Element>(tmp) : Caster<Element>(std::fmod(tmp, _pc));
         return negin(r);
     }
 

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -111,12 +111,13 @@ namespace Givaro {
 		// -- maxCardinality
 		// -- Rules: Storage_t | Compute_t | maxCardinality
 		// --        ----------+-----------+---------------
-		// --        (u)intN_t |  uintN_t  | 2^(N/2) - 1
+		// --        (u)intN_t |  uintN_t  | 2^(N/2) - 1: could be 2^(N/2) but provokes errors in fflas-ffpack
 		// --          intN_t  | uint2N_t  | 2^(N-1) - 1
-		// --         uintN_t  | uint2N_t  |   2^(N-1) - 1 //NOTE: because of invext (should be 2^N-1)
-		// --         float    |  float    |  2896    // Old values (TODO: check)
-		// --         double   |  double   | 94906266 // Old values (TODO: check)
-		// --         Integer  |  Integer  | 0
+		// --         uintN_t  | uint2N_t  | 2^(N-1) - 1: could be 2^N-1 but for invext
+		// --         float    |  float    | 4096: 2^12
+		// --         double   |  double   | 94906266: floor(2^27 sqrt(2) + 1/2)
+		// --         float    |  double   | 16777216: 2^24
+		// --         Integer  |  Integer  | None
 		// --         ruint<K> |  ruint<K> | ruint<K>::maxCardinality()
 		// --         ruint<K> | ruint<K+1>| (ruint<K+1>::maxCardinality()-1).Low/2
 
@@ -139,8 +140,11 @@ namespace Givaro {
 			return repunit >> 1; // 2^(N-1)-1 with N = bitsize(Storage_t) // NOTE: should be 2^N-1
 		}
 
-		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float))
-		static Residu_t maxCardinality() { return 2896; }
+		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && IS_SAME(S, Compute_t))
+		static Residu_t maxCardinality() { return 4096; }
+
+		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && !IS_SAME(S, Compute_t))
+		static Residu_t maxCardinality() { return 16777216; }
 
 		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, double))
 		static Residu_t maxCardinality() { return 94906266; }

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -109,6 +109,11 @@ namespace Givaro {
 		static inline Residu_t minCardinality() { return 2; }
 
 		// -- maxCardinality
+		// -- Goal: being able to store in Compute_t the result of x*y + z
+		// --       when x, y and z belong to Storage_t
+		// -- => Storage_t must store integers up to maxCardinality-1
+		// -- => Compute_t must store integers up to p(p-1) where p = maxCardinality
+
 		// -- Rules: Storage_t | Compute_t | maxCardinality
 		// --        ----------+-----------+---------------
 		// --        (u)intN_t |  uintN_t  | 2^(N/2) - 1: could be 2^(N/2) but provokes errors in fflas-ffpack
@@ -125,7 +130,8 @@ namespace Givaro {
 		static Residu_t maxCardinality() {
 			std::size_t k = sizeof(S);
 			Residu_t repunit = ~0;
-			return repunit >> 4*k; // 2^(N/2) - 1 with N = bitsize(Storage_t)
+			return repunit >> (k << 2);
+			//return (Residu_t)1 << (k << 2); // 2^(N/2) with N = bitsize(Storage_t)
 		}
 
 		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SINT(S) && (2*sizeof(S) == sizeof(Compute_t)))

--- a/src/kernel/ring/modular-integral.inl
+++ b/src/kernel/ring/modular-integral.inl
@@ -148,17 +148,14 @@ namespace Givaro {
         inline typename MOD::Element& MOD::mul
         (Element& r, const Element& a, const Element& b) const
         {
-            return r = Caster<Element>(Caster<Compute_t>(a)*Caster<Compute_t>(b) % Caster<Compute_t>(_p));
+            return r = Caster<Element>(Caster<Compute_t>(a)*Caster<Compute_t>(b) % _pc);
         }
 
         TMPL
         inline typename MOD::Element& MOD::sub
         (Element& r, const Element& a, const Element& b) const
         {
-            return r = Caster<Element>((Caster<Compute_t>(a) >= Caster<Compute_t>(b)) ?
-                Caster<Compute_t>(a)-Caster<Compute_t>(b) :
-                Caster<Compute_t>(_p)-Caster<Compute_t>(b)+Caster<Compute_t>(a));
-            //TODO: Caster necessary? define variables...
+            return r = (a < b) ? (Caster<Element>(_p) - b) + a : a - b;
         }
 
         TMPL
@@ -166,14 +163,14 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             Compute_t tmp = Caster<Compute_t>(a) + Caster<Compute_t>(b);
-            return r = Caster<Element>((tmp < Caster<Compute_t>(_p)) ? tmp : tmp - Caster<Compute_t>(_p));
+            return r = Caster<Element>((tmp < _pc) ? tmp : tmp - _pc);
         }
 
         TMPL
         inline typename MOD::Element& MOD::neg
         (Element& r, const Element& a) const
         {
-            return r = (a == 0) ? Caster<Element>(0) : Caster<Element>(Caster<Compute_t>(_p)-Caster<Compute_t>(a));
+            return r = (a == 0) ? Caster<Element>(0) : Caster<Element>(_p) - a;
         }
 
         TMPL
@@ -181,7 +178,7 @@ namespace Givaro {
         (Element& r, const Element& a) const
         {
             invext(r, a, Caster<Element>(_p));
-            return (r < 0)? r += _p : r;
+            return (r < 0)? r += Caster<Element>(_p) : r;
         }
 
         TMPL
@@ -195,7 +192,7 @@ namespace Givaro {
         inline typename MOD::Element& MOD::mulin
         (Element& r, const Element& a) const
         {
-            return r = Caster<Element>(Caster<Compute_t>(r)*Caster<Compute_t>(a) % Caster<Compute_t>(_p));
+            return r = Caster<Element>(Caster<Compute_t>(r)*Caster<Compute_t>(a) % _pc);
         }
 
         TMPL
@@ -210,25 +207,23 @@ namespace Givaro {
         inline typename MOD::Element& MOD::addin
         (Element& r, const Element& a) const
         {
-            Compute_t tmp = Caster<Compute_t>(r) + Caster<Compute_t>(a);
-            return r = Caster<Element>((tmp < _p) ? tmp : tmp - _p);
-            //TODO: No need to cast to Compute_t: detect overflow
+			r += a;
+			return r = (r >= Caster<Element>(_p) || r < a) ? r - Caster<Element>(_p) : r;
         }
 
         TMPL
         inline typename MOD::Element& MOD::subin
         (Element& r, const Element& a) const
         {
-            Compute_t rc = Caster<Compute_t>(r), ac = Caster<Compute_t>(a);
-            return r = Caster<Element>((rc < ac) ? Caster<Compute_t>(_p) + rc - ac : rc - ac);
+			return r = (r < a) ? (Caster<Element>(_p) - a) + r : r - a;
         }
 
         TMPL
         inline typename MOD::Element& MOD::negin
         (Element& r) const
         {
-            return r = (r == 0) ? (Element)0 : Caster<Element>(Caster<Compute_t>(_p)-Caster<Compute_t>(r));
-        }
+            return r = (r == 0) ? (Element)0 : Caster<Element>(_p) - r;
+		}
 
         TMPL
         inline typename MOD::Element& MOD::invin
@@ -249,7 +244,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b, const Element& c) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(c)) % Caster<Compute_t>(_p));
+                        + Caster<Compute_t>(c)) % _pc);
         }
 
         TMPL
@@ -257,16 +252,16 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(r)) % Caster<Compute_t>(_p));
+                        + Caster<Compute_t>(r)) % _pc);
         }
 
         TMPL
         inline typename MOD::Element& MOD::maxpy
         (Element& r, const Element& a, const Element& b, const Element& c) const
         {
-            Element tmp;
-            return r = sub(r, c, mul(tmp, a, b));
-            // TODO: Use only one modulo?
+			r = Caster<Element>((Caster<Compute_t>(a) * Caster<Compute_t>(b)
+							+ (_pc - Caster<Compute_t>(c))) % _pc);
+			return r = negin(r);
         }
 
         TMPL
@@ -274,7 +269,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b, const Element& c) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(_p)-Caster<Compute_t>(c)) % Caster<Compute_t>(_p));
+                        + _pc-Caster<Compute_t>(c)) % _pc);
         }
 
         TMPL
@@ -282,7 +277,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                + Caster<Compute_t>(_p) -Caster<Compute_t>(r)) % Caster<Compute_t>(_p));
+                + _pc -Caster<Compute_t>(r)) % _pc);
             return r = negin(r);
         }
 
@@ -291,7 +286,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(_p)-Caster<Compute_t>(r)) % Caster<Compute_t>(_p));
+                        + _pc-Caster<Compute_t>(r)) % _pc);
         }
 
 #undef MOD

--- a/src/kernel/ring/modular-integral.inl
+++ b/src/kernel/ring/modular-integral.inl
@@ -162,8 +162,8 @@ namespace Givaro {
         inline typename MOD::Element& MOD::add
         (Element& r, const Element& a, const Element& b) const
         {
-            Compute_t tmp = Caster<Compute_t>(a) + Caster<Compute_t>(b);
-            return r = Caster<Element>((tmp < _pc) ? tmp : tmp - _pc);
+			r = a + b;
+			return (r >= Caster<Element>(_p) || r < a) ? r -= Caster<Element>(_p) : r;
         }
 
         TMPL


### PR DESCRIPTION
While there was theoretical support for the instantiation `Modular<float,double>`, it was not really supported: All computations were actually performed in `float`s so this instantiation did the exact same thing as `Modular<float,float>`. This PR changes this to make `Modular<float, double>` have an interest! 

The method `maxCardinality` is updated to reflect these changes.

As side changes, the file `modular-integral.inl` is modified to make use of the attribute `_pc` which has type `Compute_t`, and stop using `Caster<Compute_t>(_p)`.