### PR TITLE
Invext without signed integer

### DIFF
--- a/src/kernel/ring/modular-floating.inl
+++ b/src/kernel/ring/modular-floating.inl
@@ -75,16 +75,16 @@ namespace Givaro {
     TMPL
     inline typename MOD::Element&  MOD::reduce (Element& x) const
     {
-        x = std::fmod(x, _pc);
-        if (x < 0) x += _pc;
+        x = std::fmod(x, Caster<Element>(_pc));
+        if (x < 0) x += Caster<Element>(_pc);
         return x;
     }
 
     TMPL
     inline typename MOD::Element&  MOD::reduce (Element& x, const Element& y) const
     {
-        x = std::fmod(y, _pc);
-        if (x < 0.f) x += _pc;
+        x = std::fmod(y, Caster<Element>(_pc));
+        if (x < 0.f) x += Caster<Element>(_pc);
         return x;
     }
 
@@ -95,22 +95,22 @@ namespace Givaro {
     inline typename MOD::Element & MOD::add
     (Element &x, const Element &y, const Element &z) const
     {
-        x = y + z;
-        return x = (x<_pc?x:x-_pc);
+        Compute_t tmp = Caster<Compute_t>(y) + Caster<Compute_t>(z);
+        return x = Caster<Element>(tmp<_pc?tmp:tmp-_pc);
     }
 
     TMPL
     inline typename MOD::Element & MOD::sub
     (Element &x, const Element &y, const Element &z) const
     {
-        return x = (y>=z)? y-z:(_pc-z)+y;
+        return x = (y>=z)? y-z:(Caster<Element>(_pc)-z)+y;
     }
 
     TMPL
     inline typename MOD::Element & MOD::mul
     (Element &x, const Element &y, const Element &z) const
     {
-        return x = std::fmod(y*z, _pc);
+        return x = Caster<Element>(std::fmod(Caster<Compute_t>(y)*Caster<Compute_t>(z), _pc));
     }
 
     TMPL
@@ -124,31 +124,30 @@ namespace Givaro {
     inline typename MOD::Element & MOD::neg
     (Element &x, const Element &y) const
     {
-        return x = (y==0?0:_pc-y);
+        return x = (y==Caster<Element>(0)?Caster<Element>(0):Caster<Element>(_pc)-y);
     }
 
     TMPL
     inline typename MOD::Element & MOD::inv
     (Element &x, const Element &y) const
     {
-        invext(x,y,Caster<Element>(_p));
-        return (x<0 ? x+=Caster<Element>(_p) : x);
-        return x;
-        }
+        invext(x,y,Caster<Element>(_pc));
+        return (x<Caster<Element>(0) ? x+=Caster<Element>(_pc) : x);
+    }
 
     TMPL
     inline typename MOD::Element & MOD::addin
     (Element &x, const Element &y) const
     {
-        x += y;
-        return x = (x<_pc?x:x-_pc);
+	Compute_t tmp = Caster<Compute_t>(x) + Caster<Compute_t>(y);
+        return x = Caster<Element>(tmp < _pc? tmp : tmp - _pc);
     }
 
     TMPL
     inline typename MOD::Element & MOD::subin
     (Element &x, const Element &y) const
     {
-        if (x<y) x += (_pc-y);
+        if (x<y) x += (Caster<Element>(_pc)-y);
         else     x -= y;
         return x;
     }
@@ -157,7 +156,7 @@ namespace Givaro {
     inline typename MOD::Element & MOD::mulin
     (Element &x, const Element &y) const
     {
-        return x = std::fmod(x*y, _pc);
+        return x = Caster<Element>(std::fmod(Caster<Compute_t>(x)*Caster<Compute_t>(y), _pc));
     }
 
     TMPL
@@ -172,7 +171,7 @@ namespace Givaro {
     inline typename MOD::Element & MOD::negin
     (Element &x) const
     {
-        return x = (x==0?0:_pc-x);
+        return x = (x==Caster<Element>(0)?Caster<Element>(0):Caster<Element>(_pc)-x);
     }
 
     TMPL
@@ -187,14 +186,14 @@ namespace Givaro {
     inline typename MOD::Element & MOD::axpy
     (Element &r, const Element &a, const Element &x, const Element &y) const
     {
-        return r = std::fmod(a*x+y, _pc);
+        return r = Caster<Element>(std::fmod(Caster<Compute_t>(a)*Caster<Compute_t>(x)+Caster<Compute_t>(y), _pc));
     }
 
     TMPL
     inline typename MOD::Element & MOD::axpyin
     (Element &r, const Element &a, const Element &x) const
     {
-        return r = std::fmod(a*x + r, _pc);
+        return r = Caster<Element>(std::fmod(Caster<Compute_t>(a)*Caster<Compute_t>(x)+Caster<Compute_t>(r), _pc));
     }
 
     // -- axmy: r <- a * x - y
@@ -202,7 +201,7 @@ namespace Givaro {
     inline typename MOD::Element & MOD::axmy
     (Element& r, const Element &a, const Element &x, const Element &y) const
     {
-        return r = std::fmod(a*x + (_pc-y), _pc);
+        return r = Caster<Element>(std::fmod(Caster<Compute_t>(a)*Caster<Compute_t>(x) + (_pc-Caster<Compute_t>(y)), _pc));
     }
 
     TMPL
@@ -218,8 +217,8 @@ namespace Givaro {
     inline typename MOD::Element&  MOD::maxpy
     (Element& r, const Element& a, const Element& x, const Element& y) const
     {
-        r = a*x + (_pc-y);
-        r = (r<_pc ? r : std::fmod(r,_pc));
+	r = Caster<Element>(std::fmod(Caster<Compute_t>(a) * Caster<Compute_t>(x)
+			+ (_pc - Caster<Compute_t>(y)), _pc));
         return negin(r);
     }
 
@@ -227,8 +226,8 @@ namespace Givaro {
     inline typename MOD::Element&  MOD::maxpyin
     (Element& r, const Element& a, const Element& x) const
     {
-        r = a*x + (_pc-r);
-        r = (r<_pc ? r : std::fmod(r,_pc));
+	Compute_t tmp = Caster<Compute_t>(a) * Caster<Compute_t>(x) + (_pc - Caster<Compute_t>(r));
+	r = (tmp < _pc) ? Caster<Element>(tmp) : Caster<Element>(std::fmod(tmp, _pc));
         return negin(r);
     }
 

--- a/src/kernel/ring/modular-general.inl
+++ b/src/kernel/ring/modular-general.inl
@@ -15,17 +15,6 @@
 #include <cmath>
 #include <type_traits>
 
-template<typename T, typename Enable = void>
-struct make_signed_int {
-    typedef T type;
-};
-
-template<typename T>
-struct make_signed_int<T,
-    typename  std::enable_if<std::is_integral<T>::value>::type> {
-    typedef typename std::make_signed<T>::type type;
-};
-
 // int64_t for double and int32_t for float
 template<bool IsFloat=false> struct IntType {
     typedef int64_t type;
@@ -34,12 +23,6 @@ template<bool IsFloat=false> struct IntType {
 template<> struct IntType<true> {
     typedef int32_t type;
     typedef uint32_t utype;
-};
-
-template<typename T>
-struct make_signed_int<T,
-    typename std::enable_if<std::is_floating_point<T>::value>::type> {
-    typedef typename IntType<std::is_same<T,float>::value>::type type;
 };
 
 template<typename T, typename Enable = void>
@@ -65,12 +48,6 @@ template<size_t K> struct is_smaller_ruint<RecInt::ruint<K>,RecInt::ruint<K+1>> 
 template<typename T> struct RecInt_K;
 template<size_t K> struct RecInt_K<RecInt::ruint<K>> { static const size_t value = K;};
 
-template<typename T>
-struct make_signed_int<T,
-    typename std::enable_if<is_ruint<T>::value>::type> {
-    typedef typename RecInt::rint<RecInt_K<T>::value> type;
-};
-
 namespace Givaro
 {
 
@@ -78,26 +55,35 @@ namespace Givaro
     inline typename std::enable_if<!std::is_floating_point<Storage_t>::value, Storage_t&>::type
     invext(Storage_t& x, Storage_t& d, const Storage_t a, const Storage_t b)
     {
-        using Signed_t = typename make_signed_int<Storage_t>::type;
 
-        Signed_t u0(0), r0 = Caster<Signed_t>(b);
-        Signed_t u1(1), r1 = Caster<Signed_t>(a);
-        while (r1 != (Signed_t)0)
+        Storage_t u0(0), u1(1), r1(a), q, t;
+        d = b;
+
+        bool neg = true;
+
+        while (r1 != (Storage_t)0)
         {
-            Signed_t q(r0 / r1);
-            Signed_t t(u1);
-            u1 = u0 - q * u1;
+            // Invariants:
+            // - if !neg:
+            //     u0 * a = d (mod b)
+            //     u1 * a = -r1 (mod b)
+            // - if neg:
+            //     u0 * a = -d (mod b)
+            //     u1 * a = r1 (mod b)
+
+            q = d / r1;
+            t = u1;
+            u1 = q * u1 + u0;
             u0 = t;
 
             t = r1;
-            r1 = r0 - q * r1;
-            r0 = t;
-//         std::cerr << u0 << '*' << a << "+ .*" << b << '=' << r0 << std::endl;
-//         std::cerr << u1 << '*' << a << "+ .*" << b << '=' << r1 << std::endl;
+            r1 = d - q * r1;
+            d = t;
+
+            neg = !neg;
         }
-        Caster<Storage_t>(d, r0);
-//         std::cerr << u0 << '*' << a << "+ .*" << b << '=' << r0 << std::endl;
-        return x = ( u0<0 ? Caster<Storage_t>(u0+Caster<Signed_t>(b)) : Caster<Storage_t>(u0) );
+
+        return x = (neg && u0 > 0) ? b - u0 : u0;
     }
 
     template<typename Storage_t>

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -118,7 +118,7 @@ namespace Givaro {
 		// --        ----------+-----------+---------------
 		// --        (u)intN_t |  uintN_t  | 2^(N/2) - 1: could be 2^(N/2) but provokes errors in fflas-ffpack
 		// --          intN_t  | uint2N_t  | 2^(N-1) - 1
-		// --         uintN_t  | uint2N_t  | 2^(N-1) - 1: could be 2^N-1 but for invext
+		// --         uintN_t  | uint2N_t  | 2^N - 1
 		// --         float    |  float    | 4096: 2^12
 		// --         double   |  double   | 94906266: floor(2^27 sqrt(2) + 1/2)
 		// --         float    |  double   | 16777216: 2^24
@@ -143,7 +143,7 @@ namespace Givaro {
 		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_UINT(S) && (2*sizeof(S) == sizeof(Compute_t)))
 		static Residu_t maxCardinality() {
 			Residu_t repunit = ~0;
-			return repunit >> 1; // 2^(N-1)-1 with N = bitsize(Storage_t) // NOTE: should be 2^N-1
+			return repunit; // 2^N-1 with N = bitsize(Storage_t)
 		}
 
 		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && IS_SAME(S, Compute_t))

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -111,12 +111,13 @@ namespace Givaro {
 		// -- maxCardinality
 		// -- Rules: Storage_t | Compute_t | maxCardinality
 		// --        ----------+-----------+---------------
-		// --        (u)intN_t |  uintN_t  | 2^(N/2) - 1
+		// --        (u)intN_t |  uintN_t  | 2^(N/2) - 1: could be 2^(N/2) but provokes errors in fflas-ffpack
 		// --          intN_t  | uint2N_t  | 2^(N-1) - 1
-		// --         uintN_t  | uint2N_t  |   2^(N-1) - 1 //NOTE: because of invext (should be 2^N-1)
-		// --         float    |  float    |  2896    // Old values (TODO: check)
-		// --         double   |  double   | 94906266 // Old values (TODO: check)
-		// --         Integer  |  Integer  | 0
+		// --         uintN_t  | uint2N_t  | 2^(N-1) - 1: could be 2^N-1 but for invext
+		// --         float    |  float    | 4096: 2^12
+		// --         double   |  double   | 94906266: floor(2^27 sqrt(2) + 1/2)
+		// --         float    |  double   | 16777216: 2^24
+		// --         Integer  |  Integer  | None
 		// --         ruint<K> |  ruint<K> | ruint<K>::maxCardinality()
 		// --         ruint<K> | ruint<K+1>| (ruint<K+1>::maxCardinality()-1).Low/2
 
@@ -139,8 +140,11 @@ namespace Givaro {
 			return repunit >> 1; // 2^(N-1)-1 with N = bitsize(Storage_t) // NOTE: should be 2^N-1
 		}
 
-		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float))
-		static Residu_t maxCardinality() { return 2896; }
+		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && IS_SAME(S, Compute_t))
+		static Residu_t maxCardinality() { return 4096; }
+
+		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && !IS_SAME(S, Compute_t))
+		static Residu_t maxCardinality() { return 16777216; }
 
 		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, double))
 		static Residu_t maxCardinality() { return 94906266; }

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -109,6 +109,11 @@ namespace Givaro {
 		static inline Residu_t minCardinality() { return 2; }
 
 		// -- maxCardinality
+		// -- Goal: being able to store in Compute_t the result of x*y + z
+		// --       when x, y and z belong to Storage_t
+		// -- => Storage_t must store integers up to maxCardinality-1
+		// -- => Compute_t must store integers up to p(p-1) where p = maxCardinality
+
 		// -- Rules: Storage_t | Compute_t | maxCardinality
 		// --        ----------+-----------+---------------
 		// --        (u)intN_t |  uintN_t  | 2^(N/2) - 1: could be 2^(N/2) but provokes errors in fflas-ffpack
@@ -125,7 +130,8 @@ namespace Givaro {
 		static Residu_t maxCardinality() {
 			std::size_t k = sizeof(S);
 			Residu_t repunit = ~0;
-			return repunit >> 4*k; // 2^(N/2) - 1 with N = bitsize(Storage_t)
+			return repunit >> (k << 2);
+			//return (Residu_t)1 << (k << 2); // 2^(N/2) with N = bitsize(Storage_t)
 		}
 
 		__GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SINT(S) && (2*sizeof(S) == sizeof(Compute_t)))

--- a/src/kernel/ring/modular-integral.inl
+++ b/src/kernel/ring/modular-integral.inl
@@ -148,17 +148,14 @@ namespace Givaro {
         inline typename MOD::Element& MOD::mul
         (Element& r, const Element& a, const Element& b) const
         {
-            return r = Caster<Element>(Caster<Compute_t>(a)*Caster<Compute_t>(b) % Caster<Compute_t>(_p));
+            return r = Caster<Element>(Caster<Compute_t>(a)*Caster<Compute_t>(b) % _pc);
         }
 
         TMPL
         inline typename MOD::Element& MOD::sub
         (Element& r, const Element& a, const Element& b) const
         {
-            return r = Caster<Element>((Caster<Compute_t>(a) >= Caster<Compute_t>(b)) ?
-                Caster<Compute_t>(a)-Caster<Compute_t>(b) :
-                Caster<Compute_t>(_p)-Caster<Compute_t>(b)+Caster<Compute_t>(a));
-            //TODO: Caster necessary? define variables...
+            return r = (a < b) ? (Caster<Element>(_p) - b) + a : a - b;
         }
 
         TMPL
@@ -166,14 +163,14 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             Compute_t tmp = Caster<Compute_t>(a) + Caster<Compute_t>(b);
-            return r = Caster<Element>((tmp < Caster<Compute_t>(_p)) ? tmp : tmp - Caster<Compute_t>(_p));
+            return r = Caster<Element>((tmp < _pc) ? tmp : tmp - _pc);
         }
 
         TMPL
         inline typename MOD::Element& MOD::neg
         (Element& r, const Element& a) const
         {
-            return r = (a == 0) ? Caster<Element>(0) : Caster<Element>(Caster<Compute_t>(_p)-Caster<Compute_t>(a));
+            return r = (a == 0) ? Caster<Element>(0) : Caster<Element>(_p) - a;
         }
 
         TMPL
@@ -181,7 +178,7 @@ namespace Givaro {
         (Element& r, const Element& a) const
         {
             invext(r, a, Caster<Element>(_p));
-            return (r < 0)? r += _p : r;
+            return (r < 0)? r += Caster<Element>(_p) : r;
         }
 
         TMPL
@@ -195,7 +192,7 @@ namespace Givaro {
         inline typename MOD::Element& MOD::mulin
         (Element& r, const Element& a) const
         {
-            return r = Caster<Element>(Caster<Compute_t>(r)*Caster<Compute_t>(a) % Caster<Compute_t>(_p));
+            return r = Caster<Element>(Caster<Compute_t>(r)*Caster<Compute_t>(a) % _pc);
         }
 
         TMPL
@@ -210,25 +207,23 @@ namespace Givaro {
         inline typename MOD::Element& MOD::addin
         (Element& r, const Element& a) const
         {
-            Compute_t tmp = Caster<Compute_t>(r) + Caster<Compute_t>(a);
-            return r = Caster<Element>((tmp < _p) ? tmp : tmp - _p);
-            //TODO: No need to cast to Compute_t: detect overflow
+			r += a;
+			return r = (r >= Caster<Element>(_p) || r < a) ? r - Caster<Element>(_p) : r;
         }
 
         TMPL
         inline typename MOD::Element& MOD::subin
         (Element& r, const Element& a) const
         {
-            Compute_t rc = Caster<Compute_t>(r), ac = Caster<Compute_t>(a);
-            return r = Caster<Element>((rc < ac) ? Caster<Compute_t>(_p) + rc - ac : rc - ac);
+			return r = (r < a) ? (Caster<Element>(_p) - a) + r : r - a;
         }
 
         TMPL
         inline typename MOD::Element& MOD::negin
         (Element& r) const
         {
-            return r = (r == 0) ? (Element)0 : Caster<Element>(Caster<Compute_t>(_p)-Caster<Compute_t>(r));
-        }
+            return r = (r == 0) ? (Element)0 : Caster<Element>(_p) - r;
+		}
 
         TMPL
         inline typename MOD::Element& MOD::invin
@@ -249,7 +244,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b, const Element& c) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(c)) % Caster<Compute_t>(_p));
+                        + Caster<Compute_t>(c)) % _pc);
         }
 
         TMPL
@@ -257,16 +252,16 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(r)) % Caster<Compute_t>(_p));
+                        + Caster<Compute_t>(r)) % _pc);
         }
 
         TMPL
         inline typename MOD::Element& MOD::maxpy
         (Element& r, const Element& a, const Element& b, const Element& c) const
         {
-            Element tmp;
-            return r = sub(r, c, mul(tmp, a, b));
-            // TODO: Use only one modulo?
+			r = Caster<Element>((Caster<Compute_t>(a) * Caster<Compute_t>(b)
+							+ (_pc - Caster<Compute_t>(c))) % _pc);
+			return r = negin(r);
         }
 
         TMPL
@@ -274,7 +269,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b, const Element& c) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(_p)-Caster<Compute_t>(c)) % Caster<Compute_t>(_p));
+                        + _pc-Caster<Compute_t>(c)) % _pc);
         }
 
         TMPL
@@ -282,7 +277,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                + Caster<Compute_t>(_p) -Caster<Compute_t>(r)) % Caster<Compute_t>(_p));
+                + _pc -Caster<Compute_t>(r)) % _pc);
             return r = negin(r);
         }
 
@@ -291,7 +286,7 @@ namespace Givaro {
         (Element& r, const Element& a, const Element& b) const
         {
             return r = Caster<Element>((Caster<Compute_t>(a)*Caster<Compute_t>(b)
-                        + Caster<Compute_t>(_p)-Caster<Compute_t>(r)) % Caster<Compute_t>(_p));
+                        + _pc-Caster<Compute_t>(r)) % _pc);
         }
 
 #undef MOD

--- a/src/kernel/ring/modular-integral.inl
+++ b/src/kernel/ring/modular-integral.inl
@@ -162,8 +162,8 @@ namespace Givaro {
         inline typename MOD::Element& MOD::add
         (Element& r, const Element& a, const Element& b) const
         {
-            Compute_t tmp = Caster<Compute_t>(a) + Caster<Compute_t>(b);
-            return r = Caster<Element>((tmp < _pc) ? tmp : tmp - _pc);
+			r = a + b;
+			return (r >= Caster<Element>(_p) || r < a) ? r -= Caster<Element>(_p) : r;
         }
 
         TMPL


### PR DESCRIPTION
This PR (that depends on the branch of #71 and thus should be merged after) changes the implementation of `invext` for non-floating point types in `src/kernel/ring/modular-general.inl` so that it only uses non negative integers. (It is of course still an extended euclidean algorithm.)

The rationale is for inputs of type `uintN_t` (for some `N`) to avoid a cast to `intN_t` (or `int2N_t`). In particular, this implies that `Modular<uintN_t,uint2N_t>` now has `maxCardinality` set to 2^N-1 rather than 2^(N-1) - 1 as it was before.