### PR TITLE
Remove most warnings

### DIFF
--- a/src/kernel/field/gfq.h
+++ b/src/kernel/field/gfq.h
@@ -183,7 +183,7 @@ public:
     Rep& indeterminate(Rep&) const;
     
  	// Initialization of Elements
-    Rep& init(Rep& r) const { return r=zero;}
+    Rep& init(Rep& r) const override { return r=zero;}
     Rep& init( Rep&, const int32_t) const ;
     Rep& init( Rep&, const uint32_t) const ;
     Rep& init( Rep&, const int64_t) const ;
@@ -206,16 +206,16 @@ public:
     
 	// -- Misc: r <- a mod p
     Rep& assign (Rep&, const Integer) const;
-    Rep& assign (Rep&, const Rep&) const;
+    Rep& assign (Rep&, const Rep&) const override;
     void assign ( const size_t sz, Array r, constArray a ) const;
     
 	// --- IO methods for the Domain
     std::istream& read ( std::istream& s );
-    std::ostream& write( std::ostream& s ) const;
+    std::ostream& write( std::ostream& s ) const override;
     std::ostream& write( std::ostream& s , const std::string& ) const;
 	// --- IO methods for the Elements
-    std::istream& read ( std::istream& s, Rep& a ) const;
-    std::ostream& write( std::ostream& s, const Rep& a ) const;
+    std::istream& read ( std::istream& s, Rep& a ) const override;
+    std::ostream& write( std::ostream& s, const Rep& a ) const override;
     
 	// Conversions of the elements
     std::ostream& convert(std::ostream& s, const Rep a ) const { return write(s,a); }
@@ -233,30 +233,30 @@ public:
 	inline int operator!= (const GFqDom<TT>& a) const;
 
 	// Miscellaneous functions
-	bool areEqual(const Rep& a, const Rep& b) const;
+	bool areEqual(const Rep& a, const Rep& b) const override;
 	bool areNEqual(const Rep, const Rep) const;
-	bool isZero(const Rep& a) const;
+	bool isZero(const Rep& a) const override;
 	bool isnzero(const Rep) const;
-	bool isOne(const Rep& a) const;
-	bool isMOne(const Rep& a) const;
-	bool isUnit(const Rep& a) const; // Element belongs to prime subfield
+	bool isOne(const Rep& a) const override;
+	bool isMOne(const Rep& a) const override;
+	bool isUnit(const Rep& a) const override; // Element belongs to prime subfield
 	size_t length( const Rep ) const;
 
 
 
 	// ----- Operations with reduction: r <- a op b mod p, r <- op a mod p
-	Rep& mul (Rep& r, const Rep& a, const Rep& b) const;
+	Rep& mul (Rep& r, const Rep& a, const Rep& b) const override;
 	Rep& div (Rep& r, const Rep a, const Rep b) const;
-	Rep& add (Rep& r, const Rep& a, const Rep& b) const;
-	Rep& sub (Rep& r, const Rep& a, const Rep& b) const;
-	Rep& neg (Rep& r, const Rep& a) const;
+	Rep& add (Rep& r, const Rep& a, const Rep& b) const override;
+	Rep& sub (Rep& r, const Rep& a, const Rep& b) const override;
+	Rep& neg (Rep& r, const Rep& a) const override;
 	Rep& inv (Rep& r, const Rep a) const;
 
-	Rep& mulin (Rep& r, const Rep& a) const;
+	Rep& mulin (Rep& r, const Rep& a) const override;
 	Rep& divin (Rep& r, const Rep a) const;
-	Rep& addin (Rep& r, const Rep& a) const;
-	Rep& subin (Rep& r, const Rep& a) const;
-	Rep& negin (Rep& r) const;
+	Rep& addin (Rep& r, const Rep& a) const override;
+	Rep& subin (Rep& r, const Rep& a) const override;
+	Rep& negin (Rep& r) const override;
 	Rep& invin (Rep& r) const;
 
 	// ----- Operations with reduction: r <- a op b mod p, r <- op a mod p
@@ -274,24 +274,24 @@ public:
 	void neg (const size_t sz, Array r, constArray a) const;
 	void inv (const size_t sz, Array r, constArray a) const;
 
-	Rep& axpy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const;
+	Rep& axpy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const override;
 	void axpy (const size_t sz, Array r, Rep a, constArray x, constArray y) const;
 	void axpy (const size_t sz, Array r, Rep a, constArray x, Rep c) const;
 
 	// -- axpyin: r <- r + a * x mod p
-	Rep& axpyin (Rep& r, const Rep& a, const Rep& b) const;
+	Rep& axpyin (Rep& r, const Rep& a, const Rep& b) const override;
 	void axpyin (const size_t sz, Array r, Rep a, constArray x) const;
 
 	// -- axmy: r <- a * b - c mod p
-	Rep& axmy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const;
+	Rep& axmy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const override;
 	void axmy (const size_t sz, Array r, Rep a, constArray x, constArray y) const;
 	void axmy (const size_t sz, Array r, Rep a, constArray x, Rep c) const;
 
 	// -- maxpy: r <- c - a * b mod p
-	Rep& maxpy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const;
+	Rep& maxpy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const override;
 
 	// -- axmyin: r <-  a * b - r mod p
-	Rep& axmyin (Rep& r, const Rep& a, const Rep& b) const;
+	Rep& axmyin (Rep& r, const Rep& a, const Rep& b) const override;
 	// void axmyin (const size_t sz, Array r, Rep a, constArray x) const;
 
 	//   // -- sqpyin: r <- r + a * a mod p
@@ -299,7 +299,7 @@ public:
 
 
 	// -- maxpyin: r <- r - a * b mod p
-	Rep& maxpyin (Rep& r, const Rep& a, const Rep& b) const;
+	Rep& maxpyin (Rep& r, const Rep& a, const Rep& b) const override;
 	void maxpyin (const size_t sz, Array r, Rep a, constArray x) const;
 
 	// <- \sum_i a[i], return 1 if a.size() ==0,

--- a/src/kernel/ring/modular-balanced-double.h
+++ b/src/kernel/ring/modular-balanced-double.h
@@ -98,7 +98,7 @@ namespace Givaro
 	}
 
 	// ----- Initialisation
-	Element& init(Element& a) const;
+	Element& init(Element& a) const override;
 	Element& init(Element& r, const float a) const;
 	Element& init(Element& r, const double a) const;
 	Element& init(Element& r, const int64_t a) const;
@@ -107,7 +107,7 @@ namespace Givaro
 	template<typename T> Element& init(Element& r, const T& a) const
 	{ r = Caster<Element>(a); return reduce(r); }
 
-	Element& assign(Element& r, const Element& a) const;
+	Element& assign(Element& r, const Element& a) const override;
 
 	// ----- Convert
 	template<typename T> T& convert(T& r, const Element& a) const
@@ -157,9 +157,9 @@ namespace Givaro
 	    return a; }
 
 	// --- IO methods
-	std::ostream& write(std::ostream& s) const;
-	std::istream& read (std::istream& s, Element& a) const;
-	std::ostream& write(std::ostream& s, const Element& a) const;
+	std::ostream& write(std::ostream& s) const override;
+	std::istream& read (std::istream& s, Element& a) const override;
+	std::ostream& write(std::ostream& s, const Element& a) const override;
 
     protected:
 

--- a/src/kernel/ring/modular-balanced-float.h
+++ b/src/kernel/ring/modular-balanced-float.h
@@ -97,7 +97,7 @@ namespace Givaro
 	}
 
 	// ----- Initialisation
-	Element& init(Element& a) const;
+	Element& init(Element& a) const override;
 	Element& init(Element& r, const float a) const;
 	Element& init(Element& r, const double a) const;
 	Element& init(Element& r, const int32_t a) const;
@@ -108,7 +108,7 @@ namespace Givaro
 	template<typename T> Element& init(Element& r, const T& a) const
 	{ r = Caster<Element>(a); return reduce(r); }
 
-	Element& assign(Element& r, const Element& a) const;
+	Element& assign(Element& r, const Element& a) const override;
 
 	// ----- Convert
 	template<typename T> T& convert(T& r, const Element& a) const
@@ -158,9 +158,9 @@ namespace Givaro
 	    return a; }
 
 	// --- IO methods
-	std::ostream& write(std::ostream& s) const;
-	std::istream& read (std::istream& s, Element& a) const;
-	std::ostream& write(std::ostream& s, const Element& a) const;
+	std::ostream& write(std::ostream& s) const override;
+	std::istream& read (std::istream& s, Element& a) const override;
+	std::ostream& write(std::ostream& s, const Element& a) const override;
 
     protected:
 

--- a/src/kernel/ring/modular-balanced-int32.h
+++ b/src/kernel/ring/modular-balanced-int32.h
@@ -94,7 +94,7 @@ namespace Givaro
             }
 
             // ----- Initialisation
-        Element& init(Element& a) const;
+        Element& init(Element& a) const override;
         Element& init(Element& r, const float a) const;
         Element& init(Element& r, const double a) const;
         Element& init(Element& r, const int64_t a) const;
@@ -103,7 +103,7 @@ namespace Givaro
         template<typename T> Element& init(Element& r, const T& a) const
             { r = Caster<Element>(a); return reduce(r); }
 
-        Element& assign(Element& r, const Element& a) const;
+        Element& assign(Element& r, const Element& a) const override;
 
             // ----- Convert
         template<typename T> T& convert(T& r, const Element& a) const
@@ -153,9 +153,9 @@ namespace Givaro
             return a; }
 
             // --- IO methods
-        std::ostream& write(std::ostream& s) const;
-        std::istream& read (std::istream& s, Element& a) const;
-        std::ostream& write(std::ostream& s, const Element& a) const;
+        std::ostream& write(std::ostream& s) const override;
+        std::istream& read (std::istream& s, Element& a) const override;
+        std::ostream& write(std::ostream& s, const Element& a) const override;
 	
     protected:
 

--- a/src/kernel/ring/modular-balanced-int64.h
+++ b/src/kernel/ring/modular-balanced-int64.h
@@ -93,14 +93,14 @@ namespace Givaro
             }
 
             // ----- Initialisation
-        Element& init(Element& a) const;
+        Element& init(Element& a) const override;
         Element& init(Element& r, const float a) const;
         Element& init(Element& r, const double a) const;
         Element& init(Element& r, const Integer& a) const;
         template<typename T> Element& init(Element& r, const T& a) const
             { r = Caster<Element>(a); return reduce(r); }
 
-        Element& assign(Element& r, const Element& a) const;
+        Element& assign(Element& r, const Element& a) const override;
 
             // ----- Convert
         template<typename T> T& convert(T& r, const Element& a) const
@@ -150,9 +150,9 @@ namespace Givaro
             return a; }
 
             // --- IO methods
-        std::ostream& write(std::ostream& s) const;
-        std::istream& read (std::istream& s, Element& a) const;
-        std::ostream& write(std::ostream& s, const Element& a) const;
+        std::ostream& write(std::ostream& s) const override;
+        std::istream& read (std::istream& s, Element& a) const override;
+        std::ostream& write(std::ostream& s, const Element& a) const override;
 	
     protected:
 

--- a/src/kernel/ring/modular-floating.h
+++ b/src/kernel/ring/modular-floating.h
@@ -71,7 +71,7 @@ namespace Givaro
 			sizeof(Source) >= sizeof(Storage_t))
 		inline Element& init (Element&, const Source) const;
         
-		inline Element& init (Element&, const Integer&) const;
+		inline Element& init (Element&, const Integer&) const override;
 
 		__GIVARO_CONDITIONAL_TEMPLATE(Source, 
 			!(std::is_integral<Source>::value && sizeof(Source) >= sizeof(Storage_t)) &&

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -245,6 +245,7 @@ namespace Givaro {
     	// ----- IO
 
 
+		using FiniteFieldInterface<_Storage_t>::init;
 		virtual Element& init (Element&, const Integer&) const = 0;
 
 		inline std::ostream& write (std::ostream& s, const Element& a) const override

--- a/src/kernel/ring/modular-integral.h
+++ b/src/kernel/ring/modular-integral.h
@@ -74,7 +74,7 @@ namespace Givaro {
 		__GIVARO_CONDITIONAL_TEMPLATE(Source, IS_FLOAT(Source) && sizeof(Source) >= sizeof(Storage_t) && IS_UINT(Storage_t))
 		inline Element& init (Element&, const Source) const;
 
-		inline Element& init (Element&, const Integer&) const;
+		inline Element& init (Element&, const Integer&) const override;
 
 		__GIVARO_CONDITIONAL_TEMPLATE(Source, IS_UINT(Storage_t)
 						&&!(IS_INT(Source) && (sizeof(Source) > sizeof(Storage_t)))

--- a/src/kernel/ring/modular-inttype.h
+++ b/src/kernel/ring/modular-inttype.h
@@ -57,9 +57,9 @@ namespace Givaro
         using Parent_t::mOne;
 
         // ----- Initialisation
-        Element& init (Element& x) const
+        Element& init (Element& x) const override
 	{ return x = 0; }
-        Element& init (Element& x, const Integer& y) const
+        Element& init (Element& x, const Integer& y) const override
 	{ x = y % _p; return reduce(x); }
         template<typename T> Element& init(Element& r, const T& a) const
         { r = Caster<Element>(a); return reduce(r); }

--- a/src/kernel/ring/montgomery-int32.h
+++ b/src/kernel/ring/montgomery-int32.h
@@ -123,7 +123,7 @@ namespace Givaro
         bool operator!=(const Self_t& F) const { return _p != F._p; }
 
         // ----- Initialisation
-        Element& init (Element& x) const
+        Element& init (Element& x) const override
         { return x = 0; }
         Element& init (Element& x, const double a) const;
         Element& init (Element& x, const int64_t a) const;
@@ -137,7 +137,7 @@ namespace Givaro
             return redc(r, r * _B2p);
         }
 
-        Element& assign(Element& x, const Element& y) const
+        Element& assign(Element& x, const Element& y) const override
         { return x = y; }
     
         // ----- Convert and reduce
@@ -188,9 +188,9 @@ namespace Givaro
         { while (isZero(init(a, g()))) {} return a; }
 
         // --- IO methods
-        std::ostream& write(std::ostream& s) const;
-        std::istream& read (std::istream& s, Element& a) const;
-        std::ostream& write(std::ostream& s, const Element& a) const;
+        std::ostream& write(std::ostream& s) const override;
+        std::istream& read (std::istream& s, Element& a) const override;
+        std::ostream& write(std::ostream& s, const Element& a) const override;
 
     protected:
 

--- a/src/kernel/ring/montgomery-ruint.h
+++ b/src/kernel/ring/montgomery-ruint.h
@@ -115,7 +115,7 @@ namespace Givaro
             }
 
 	// ----- Initialisation
-        Element& init (Element& x) const
+        Element& init (Element& x) const override
         { return x = 0; }
         template<typename T> Element& init(Element& r, const T& a) const
         {
@@ -130,7 +130,7 @@ namespace Givaro
             return to_mg(r);
         }
 
-        Element& assign (Element& x, const Element& y) const
+        Element& assign (Element& x, const Element& y) const override
         { return x = y; }
     
         // ----- Convert and reduce
@@ -182,9 +182,9 @@ namespace Givaro
 
 	// --- IO methods
 	std::istream& read (std::istream& s);
-	std::ostream& write(std::ostream& s) const;
-	std::istream& read (std::istream& s, Element& a) const;
-	std::ostream& write(std::ostream& s, const Element& a) const;
+	std::ostream& write(std::ostream& s) const override;
+	std::istream& read (std::istream& s, Element& a) const override;
+	std::ostream& write(std::ostream& s, const Element& a) const override;
 
     protected:
 

--- a/src/library/poly1/givpoly1padic.h
+++ b/src/library/poly1/givpoly1padic.h
@@ -39,14 +39,7 @@ public:
     Poly1PadicDom (const Poly_t& P) : Poly_t (P), IntegerDom() {}
     Poly1PadicDom (const Poly_t& P, const IntegerDom& D) : Poly_t (P), IntegerDom(D) {}
 
-
-
-    std::ostream& write( std::ostream& o, const pol_Element& p) {
-        return Poly_t::write(o, p);
-    }
-
-
-
+    using Poly_t::write;
 
         // Horner like evaluation of the polynomial for p = _domain.size()
     template<class vect>


### PR DESCRIPTION
This PR removes most warnings which were due to virtual methods being overridden without the `override` keyword.