### PR TITLE
Bug correction for round and -= 

### DIFF
--- a/src/kernel/rational/givrataddsub.C
+++ b/src/kernel/rational/givrataddsub.C
@@ -100,9 +100,9 @@ Rational Rational::operator - (const Rational& r)  const
 Rational& Rational::operator -= (const Rational& r)
 {
     if (isZero(r)) return *this ;
-    if (isZero(*this)) {
-        num = -r.num;
-        den = -r.den;
+    if (isZero(*this)) { 
+        num = -r.num; 
+        den = r.den; 
         return *this;
     }
     if (isInteger(*this) && isInteger(r)) {

--- a/src/kernel/rational/givrataddsub.C
+++ b/src/kernel/rational/givrataddsub.C
@@ -102,7 +102,7 @@ Rational& Rational::operator -= (const Rational& r)
     if (isZero(r)) return *this ;
     if (isZero(*this)) { 
         num = -r.num; 
-        den = r.den; 
+        den = r.den; // GV Jeu  2 aoû 2018 17:30:53 CEST, a "-" was also there 
         return *this;
     }
     if (isInteger(*this) && isInteger(r)) {

--- a/src/kernel/rational/givratmisc.C
+++ b/src/kernel/rational/givratmisc.C
@@ -48,20 +48,16 @@ const Integer ceil(const Rational &x)
   return q;
 }
 
-const Integer round(const Rational& x)
+const Integer round(const Rational& x)  // GV Jeu  2 aoû 2018 16:38:58 CEST
 {
   Integer q;
   Integer r;
-  Integer::divmod(q, r, x.num, x.den);
-  r <<= 1;
-  if (absCompare(r,x.den) < 1)
-  {
-    if (sign(x.num) >= 0)
+  Integer::divmod(q, r, abs(x.num), abs(x.den));
+  r <<= 1; 
+  if (absCompare(r,x.den) > 0) // GV was < 0, and changed with abs
       q += 1;
-    else
-      q -= 1;
-  }
-  return q;
+  return sign(x)*q;
+
 }
 
 const Rational pow (const Rational& x, const int64_t y)


### PR DESCRIPTION
If I'm not wrong absCompare(r,x.den) < 0 was adding one for an initial reminder less than the half, we want the contrary.  I put abs for an additional existing issue. 