### PR TITLE
Setting CC to the correct version of gcc in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       sudo: required
       dist: trusty
       compiler: gcc
-      env: COMPILER=g++-4.9
+      env: GCC_VERSION=4.9
       addons:
         apt:
           sources:
@@ -21,7 +21,7 @@ matrix:
       sudo: required
       dist: trusty
       compiler: gcc
-      env: COMPILER=g++-5
+      env: GCC_VERSION=5
       addons:
         apt:
           sources:
@@ -35,7 +35,7 @@ matrix:
       sudo: required
       dist: trusty
       compiler: gcc
-      env: COMPILER=g++-6
+      env: GCC_VERSION=6
       addons:
         apt:
           sources:
@@ -65,14 +65,16 @@ matrix:
 
     - os: osx
       compiler: clang
-      env: COMPILER=clang++
       before_install:
       - brew update
       - brew uninstall automake && brew install automake
       - brew install autoconf libtool
 
 install:
-  - export CXX="$COMPILER"
+  - export CC=${CC}${GCC_VERSION:+-${GCC_VERSION}}
+  - echo "CC=${CC}"
+  - export CXX=${CXX}${GCC_VERSION:+-${GCC_VERSION}}
+  - echo "CXX=${CXX}"
 
 before_script:
   - ./autogen.sh


### PR DESCRIPTION
In the file `.travis.yml` used for CI, the CC variable was not set to the correct version of gcc.
For example, in the case where g++-5 was used, gcc v4.8 was the compiler detected by givaro.

This did not raise any error in Givaro, but I suspect that it is the reason why the CI is failing with Travis for FFLAS, so I will propose a similar patch for FFLAS.