### PR TITLE
Fix operator -= for Integer when *this is zero

### DIFF
--- a/src/kernel/gmp++/gmp++_int_sub.C
+++ b/src/kernel/gmp++/gmp++_int_sub.C
@@ -96,7 +96,7 @@ namespace Givaro {
 	Integer& Integer::operator -= (const uint64_t l)
 	{
 		if (l==0) return *this;
-		if (isZero(*this)) return logcpy(Integer(-l));
+		if (isZero(*this)) return logcpy(-Integer(l));
 		//   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
 		mpz_sub_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
 		return *this;
@@ -105,7 +105,7 @@ namespace Givaro {
 	Integer& Integer::operator -= (const int64_t l)
 	{
 		if (l==0) return *this;
-		if (isZero(*this)) return logcpy(Integer(-l));
+		if (isZero(*this)) return logcpy(-Integer(l));
 		//   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
 		int32_t sgn = Givaro::sign(l);
 		if (sgn >0) mpz_sub_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);

--- a/tests/test-integer.C
+++ b/tests/test-integer.C
@@ -247,6 +247,22 @@ int test_cast() {
 	return res ;
 }
 
+/* See PR#86 */
+int test_subin() {
+	Integer a;
+
+	a = 0;
+	a--;
+	if (a + 1 != 0)
+		return -1;
+
+	a = 0;
+	a-= INT64_MIN;
+	if (a + INT64_MIN != 0)
+		return -2;
+
+	return 0;
+}
 
 
 //! @todo test gcd...
@@ -272,6 +288,9 @@ int main (int argc, char ** argv)
 	if (res)
 		return res ;
 
+	res = test_subin();
+	if (res)
+		return res ;
 
 	return res ;
 }


### PR DESCRIPTION
For Integer, the `operator-=` implemented in `gmp++_int_sub.C` is buggy when `*this` is zero.
This is illustrated with the following example:

```cpp
#include <cstdint>
#include <givaro-config.h>
#include <gmp++/gmp++.h>
#include <gmp++/gmp++_int.h>

int
main (int argc, char *argv[])
{
  Givaro::Integer a = 0;
  std::cout << "a=" << a;
  a--;
  std::cout << " => a-- gives " << a-- << std::endl;
  
  a = 0;
  std::cout << "a=" << a;
  a-=INT64_MIN;
  std::cout << " => a-=" << INT64_MIN << " gives " << a << std::endl;
}
```
which outputs
```
a=0 => a-- gives 18446744073709551615
a=0 => a-=-9223372036854775808 gives -9223372036854775808
```
instead of
```
a=0 => a-- gives -1
a=0 => a-=-9223372036854775808 gives 9223372036854775808
```



The fix is simple, one should have invert a conversion to Integer and a negation.