### PR TITLE
fix undefined behaviour issue

### DIFF
--- a/src/kernel/gmp++/gmp++_int_add.C
+++ b/src/kernel/gmp++/gmp++_int_add.C
@@ -39,7 +39,7 @@ namespace Givaro {
 #else
         int32_t sgn = Givaro::sign(n);
         if (sgn >0) mpz_add_ui( (mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, n);
-        else mpz_sub_ui((mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, -n); // @fixme: check n=INT64_MIN
+        else mpz_sub_ui((mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, -static_cast<uint64_t>(n));
         return res;
 #endif
     }
@@ -71,7 +71,7 @@ namespace Givaro {
 #else
         int32_t sgn = Givaro::sign(n2);
         if (sgn >0) mpz_add_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
-        else mpz_sub_ui((mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, -n2); // @fixme: check n=INT64_MIN
+        else mpz_sub_ui((mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, -static_cast<uint64_t>(n2));
         return res;
 #endif
     }
@@ -118,7 +118,7 @@ namespace Givaro {
 #else
         int32_t sgn = Givaro::sign(l);
         if (sgn >0) mpz_add_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
-        else mpz_sub_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, -l); // @fixme: check n=INT64_MIN
+        else mpz_sub_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, -static_cast<uint64_t>(l));
         return *this;
 #endif
     }

--- a/src/kernel/gmp++/gmp++_int_sub.C
+++ b/src/kernel/gmp++/gmp++_int_sub.C
@@ -39,7 +39,7 @@ namespace Givaro {
 #else
         int32_t sgn = Givaro::sign(n);
         if (sgn >0) mpz_sub_ui( (mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, n);
-        else mpz_add_ui((mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, -n);  // @fixme: check n=INT64_MIN
+        else mpz_add_ui((mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, -static_cast<uint64_t>(n));
         return res;
 #endif
     }
@@ -71,7 +71,7 @@ namespace Givaro {
 #else
         int32_t sgn = Givaro::sign(n2);
         if (sgn >0) mpz_sub_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
-        else mpz_add_ui((mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, -n2);  // @fixme: check n=INT64_MIN
+        else mpz_add_ui((mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, -static_cast<uint64_t>(n2));
         return res;
 #endif
     }
@@ -132,7 +132,7 @@ namespace Givaro {
 #else
         int32_t sgn = Givaro::sign(l);
         if (sgn >0) mpz_sub_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
-        else mpz_add_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, -l);  // @fixme: check n=INT64_MIN
+        else mpz_add_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, -static_cast<uint64_t>(l));
         return *this;
 #endif
     }
@@ -173,7 +173,7 @@ namespace Givaro {
         Integer res;
         int32_t sgn = Givaro::sign(l);
         if (sgn >0) mpz_sub_ui( (mpz_ptr)&(res.gmp_rep), (mpz_srcptr)&gmp_rep, l);
-        else mpz_add_ui( (mpz_ptr)&(res.gmp_rep), (mpz_srcptr)&gmp_rep, -l);  // @fixme: check n=INT64_MIN
+        else mpz_add_ui( (mpz_ptr)&(res.gmp_rep), (mpz_srcptr)&gmp_rep, -static_cast<uint64_t>(l));
         return res;
 #endif
     }


### PR DESCRIPTION
From #94 , I left some `@fixme` due to the special case when - INT64_MIN  had to be computed and then casted into an `uint64_t`.
Indeed INT64_T = -2^63 fits in int64_t but -INT64_T does not.
@P1K remarked that instead, casting `-INT64_MIN` to a `uint64_t` (equald 2^63) and then taking its opposite (still 2^63) works and is a well defined behaviour.
This PR implements this change.