### PR TITLE
Removes the warning when deleting a pointer to a derived class.

### DIFF
--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -95,6 +95,8 @@ namespace Givaro {
         Modular_implem(const Self_t& F)
         : zero(F.zero), one(F.one), mOne(F.mOne), _p(F._p), _pc(F._pc) {}
 
+        virtual ~Modular_implem() = default;
+
         // ----- Accessors
         inline Element minElement() const { return zero; }
         inline Element maxElement() const { return mOne; }


### PR DESCRIPTION
Ex: linbox/algorithms/rational-solver.inl:616:20: warning: deleting object of polymorphic class type ‘Givaro::Modular<int>’ which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
     if (F != NULL) delete F;