### PR TITLE
No references in GFqDom

### DIFF
--- a/src/kernel/field/gfq.h
+++ b/src/kernel/field/gfq.h
@@ -195,7 +195,7 @@ public:
 
  	// Reduction of Elements
     Rep& reduce(Rep& r) const;
-    Rep& reduce(Rep& r, const Rep& e) const;
+    Rep& reduce(Rep& r, const Rep e) const;
     
     
 	// Initialization of a polynomial
@@ -205,7 +205,7 @@ public:
     
 	// -- Misc: r <- a mod p
     Rep& assign (Rep&, const Integer) const;
-    Rep& assign (Rep&, const Rep&) const;
+    Rep& assign (Rep&, const Rep) const;
     void assign ( const size_t sz, Array r, constArray a ) const;
     
 	// --- IO methods for the Domain
@@ -214,87 +214,87 @@ public:
     std::ostream& write( std::ostream& s , const std::string& ) const;
 	// --- IO methods for the Elements
     std::istream& read ( std::istream& s, Rep& a ) const;
-    std::ostream& write( std::ostream& s, const Rep& a ) const;
+    std::ostream& write( std::ostream& s, const Rep a ) const;
     
 	// Conversions of the elements
-    std::ostream& convert(std::ostream& s, const Rep& a ) const { return write(s,a); }
-    TT		convert(const Rep&) const ;
-    int64_t& 	convert(int64_t&, const Rep&) const ;
-    uint64_t& 	convert(uint64_t&, const Rep&) const ;
-    int32_t& 	convert(int32_t&, const Rep&) const ;
-    float&	convert(float&, const Rep&) const ;
-    double& 	convert(double&, const Rep&) const ;
-    uint32_t& 	convert(uint32_t&, const Rep&) const ;
-    Integer& 	convert(Integer&, const Rep&) const ;
+    std::ostream& convert(std::ostream& s, const Rep a ) const { return write(s,a); }
+    TT		convert(const Rep) const ;
+    int64_t& 	convert(int64_t&, const Rep) const ;
+    uint64_t& 	convert(uint64_t&, const Rep) const ;
+    int32_t& 	convert(int32_t&, const Rep) const ;
+    float&	convert(float&, const Rep) const ;
+    double& 	convert(double&, const Rep) const ;
+    uint32_t& 	convert(uint32_t&, const Rep) const ;
+    Integer& 	convert(Integer&, const Rep) const ;
 
 	// Test operators
 	inline int operator== (const GFqDom<TT>& a) const;
 	inline int operator!= (const GFqDom<TT>& a) const;
 
 	// Miscellaneous functions
-	bool areEqual(const Rep& a, const Rep& b) const;
-	bool areNEqual(const Rep&, const Rep&) const;
-	bool isZero(const Rep& a) const;
-	bool isnzero(const Rep&) const;
-	bool isOne(const Rep& a) const;
-	bool isMOne(const Rep& a) const;
-	bool isUnit(const Rep& a) const; // Element belongs to prime subfield
-	size_t length(const Rep&) const;
+	bool areEqual(const Rep a, const Rep b) const;
+	bool areNEqual(const Rep, const Rep) const;
+	bool isZero(const Rep a) const;
+	bool isnzero(const Rep) const;
+	bool isOne(const Rep a) const;
+	bool isMOne(const Rep a) const;
+	bool isUnit(const Rep a) const; // Element belongs to prime subfield
+	size_t length(const Rep) const;
 
 
 
 	// ----- Operations with reduction: r <- a op b mod p, r <- op a mod p
-	Rep& mul (Rep& r, const Rep& a, const Rep& b) const;
-	Rep& div (Rep& r, const Rep& a, const Rep& b) const;
-	Rep& add (Rep& r, const Rep& a, const Rep& b) const;
-	Rep& sub (Rep& r, const Rep& a, const Rep& b) const;
-	Rep& neg (Rep& r, const Rep& a) const;
-	Rep& inv (Rep& r, const Rep& a) const;
+	Rep& mul (Rep& r, const Rep a, const Rep b) const;
+	Rep& div (Rep& r, const Rep a, const Rep b) const;
+	Rep& add (Rep& r, const Rep a, const Rep b) const;
+	Rep& sub (Rep& r, const Rep a, const Rep b) const;
+	Rep& neg (Rep& r, const Rep a) const;
+	Rep& inv (Rep& r, const Rep a) const;
 
-	Rep& mulin (Rep& r, const Rep& a) const;
-	Rep& divin (Rep& r, const Rep& a) const;
-	Rep& addin (Rep& r, const Rep& a) const;
-	Rep& subin (Rep& r, const Rep& a) const;
+	Rep& mulin (Rep& r, const Rep a) const;
+	Rep& divin (Rep& r, const Rep a) const;
+	Rep& addin (Rep& r, const Rep a) const;
+	Rep& subin (Rep& r, const Rep a) const;
 	Rep& negin (Rep& r) const;
 	Rep& invin (Rep& r) const;
 
 	// ----- Operations with reduction: r <- a op b mod p, r <- op a mod p
 	void mul (const size_t sz, Array r, constArray a, constArray b) const;
-	void mul (const size_t sz, Array r, constArray a, const Rep& b) const;
+	void mul (const size_t sz, Array r, constArray a, const Rep b) const;
 
 	void div (const size_t sz, Array r, constArray a, constArray b) const;
-	void div (const size_t sz, Array r, constArray a, const Rep& b) const;
+	void div (const size_t sz, Array r, constArray a, const Rep b) const;
 
 	void add (const size_t sz, Array r, constArray a, constArray b) const;
-	void add (const size_t sz, Array r, constArray a, const Rep& b) const;
+	void add (const size_t sz, Array r, constArray a, const Rep b) const;
 
 	void sub (const size_t sz, Array r, constArray a, constArray b) const;
-	void sub (const size_t sz, Array r, constArray a, const Rep& b) const;
+	void sub (const size_t sz, Array r, constArray a, const Rep b) const;
 	void neg (const size_t sz, Array r, constArray a) const;
 	void inv (const size_t sz, Array r, constArray a) const;
 
-	Rep& axpy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const;
-	void axpy (const size_t sz, Array r, const Rep& a, constArray x, constArray y) const;
-	void axpy (const size_t sz, Array r, const Rep& a, constArray x, const Rep& c) const;
+	Rep& axpy (Rep& r, const Rep a, const Rep b, const Rep c) const;
+	void axpy (const size_t sz, Array r, const Rep a, constArray x, constArray y) const;
+	void axpy (const size_t sz, Array r, const Rep a, constArray x, const Rep c) const;
 
 	// -- axpyin: r <- r + a * x mod p
-	Rep& axpyin (Rep& r, const Rep& a, const Rep& b) const;
-	void axpyin (const size_t sz, Array r, const Rep& a, constArray x) const;
+	Rep& axpyin (Rep& r, const Rep a, const Rep b) const;
+	void axpyin (const size_t sz, Array r, const Rep a, constArray x) const;
 
 	// -- axmy: r <- a * b - c mod p
-	Rep& axmy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const;
-	void axmy (const size_t sz, Array r, const Rep& a, constArray x, constArray y) const;
-	void axmy (const size_t sz, Array r, const Rep& a, constArray x, const Rep& c) const;
+	Rep& axmy (Rep& r, const Rep a, const Rep b, const Rep c) const;
+	void axmy (const size_t sz, Array r, const Rep a, constArray x, constArray y) const;
+	void axmy (const size_t sz, Array r, const Rep a, constArray x, const Rep c) const;
 
 	// -- maxpy: r <- c - a * b mod p
-	Rep& maxpy (Rep& r, const Rep& a, const Rep& b, const Rep& c) const;
+	Rep& maxpy (Rep& r, const Rep a, const Rep b, const Rep c) const;
 
 	// -- axmyin: r <-  a * b - r mod p
-	Rep& axmyin (Rep& r, const Rep& a, const Rep& b) const;
+	Rep& axmyin (Rep& r, const Rep a, const Rep b) const;
 
 	// -- maxpyin: r <- r - a * b mod p
-	Rep& maxpyin (Rep& r, const Rep& a, const Rep& b) const;
-	void maxpyin (const size_t sz, Array r, const Rep& a, constArray x) const;
+	Rep& maxpyin (Rep& r, const Rep a, const Rep b) const;
+	void maxpyin (const size_t sz, Array r, const Rep a, constArray x) const;
 
 	// <- \sum_i a[i], return 1 if a.size() ==0,
 	void reduceadd ( Rep& r, const size_t sz, constArray a ) const;
@@ -310,10 +310,10 @@ public:
 
 	template<class RandIter> Rep& random(RandIter& g, Rep& r) const ;
 	template<class RandIter> Rep& random(RandIter& g, Rep& r, int64_t s) const ;
-	template<class RandIter> Rep& random(RandIter& g, Rep& r, const Rep& b) const ;
+	template<class RandIter> Rep& random(RandIter& g, Rep& r, const Rep b) const ;
 	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r) const ;
 	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r, int64_t s) const ;
-	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r, const Rep& b) const ;
+	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r, const Rep b) const ;
 
 	typedef GIV_randIter< GFqDom<TT>, Rep> RandIter;
     typedef GeneralRingNonZeroRandIter<Self_t,RandIter> NonZeroRandIter;

--- a/src/kernel/field/gfq.h
+++ b/src/kernel/field/gfq.h
@@ -310,10 +310,10 @@ public:
 
 	template<class RandIter> Rep& random(RandIter& g, Rep& r) const ;
 	template<class RandIter> Rep& random(RandIter& g, Rep& r, int64_t s) const ;
-	template<class RandIter> Rep& random(RandIter& g, Rep& r, const Rep b) const ;
+	template<class RandIter> Rep& random(RandIter& g, Rep& r, const Rep& b) const ;
 	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r) const ;
 	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r, int64_t s) const ;
-	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r, const Rep b) const ;
+	template<class RandIter> Rep& nonzerorandom(RandIter& g, Rep& r, const Rep& b) const ;
 
 	typedef GIV_randIter< GFqDom<TT>, Rep> RandIter;
     typedef GeneralRingNonZeroRandIter<Self_t,RandIter> NonZeroRandIter;

--- a/src/kernel/field/gfq.inl
+++ b/src/kernel/field/gfq.inl
@@ -277,46 +277,46 @@ namespace Givaro {
     { return a != b ; }
 
     template<typename TT>
-    inline bool GFqDom<TT>::isZero(const Rep& a) const
+    inline bool GFqDom<TT>::isZero(const Rep a) const
     { return a == GFqDom<TT>::zero ; }
 
     template<typename TT>
-    inline bool GFqDom<TT>::isnzero(const Rep& a) const
+    inline bool GFqDom<TT>::isnzero(const Rep a) const
     { return a != GFqDom<TT>::zero ; }
 
     template<typename TT>
-    inline bool GFqDom<TT>::isOne(const Rep& a) const
+    inline bool GFqDom<TT>::isOne(const Rep a) const
     { return a == GFqDom<TT>::one ; }
 
 	template<typename TT>
-    inline bool GFqDom<TT>::isMOne(const Rep& a) const
+    inline bool GFqDom<TT>::isMOne(const Rep a) const
     { return a == GFqDom<TT>::mOne ; }
 
     template<typename TT>
-    inline bool GFqDom<TT>::isUnit(const Rep& a) const
+    inline bool GFqDom<TT>::isUnit(const Rep a) const
     {
             // Fermat : x^(p-1) = 1 whenever x is a unit
         return (a!=0) && (( ( a * (_characteristic-1) ) % _qm1 ) == 0);
     }
 
     template<typename TT>
-    inline size_t GFqDom<TT>::length(const Rep& ) const
+    inline size_t GFqDom<TT>::length(const Rep ) const
     { return sizeof(TT) ;}
 
 	// ----------- Usefull method :
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::mul
-    (Rep& r, const Rep& a, const Rep& b) const
+    (Rep& r, const Rep a, const Rep b) const
     { _GIVARO_GFQ_MUL(r,a,b, GFqDom<TT>::_qm1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::mulin
-    (Rep& r, const Rep& a) const
+    (Rep& r, const Rep a) const
     { _GIVARO_GFQ_MUL(r,r,a, GFqDom<TT>::_qm1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::div
-    (Rep& r, const Rep& a, const Rep& b) const
+    (Rep& r, const Rep a, const Rep b) const
     {
 	   	_GIVARO_GFQ_DIV(r, a, b, GFqDom<TT>::_qm1) ;
 		return r;
@@ -324,32 +324,32 @@ namespace Givaro {
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::divin
-    (Rep& r, const Rep& a) const
+    (Rep& r, const Rep a) const
     { _GIVARO_GFQ_DIV(r, r, a, GFqDom<TT>::_qm1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::add
-    (Rep& r, const Rep& a, const Rep& b) const
+    (Rep& r, const Rep a, const Rep b) const
     { _GIVARO_GFQ_ADD(r, a, b, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::addin
-    (Rep& r, const Rep& a) const
+    (Rep& r, const Rep a) const
     { _GIVARO_GFQ_ADD(r, r, a, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::sub
-    (Rep& r, const Rep& a, const Rep& b) const
+    (Rep& r, const Rep a, const Rep b) const
     { _GIVARO_GFQ_SUB(r, a, b, GFqDom<TT>::mOne, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::subin
-    (Rep& r, const Rep& a) const
+    (Rep& r, const Rep a) const
     { _GIVARO_GFQ_AUTOSUB(r, a, GFqDom<TT>::mOne, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::neg
-    (Rep& r, const Rep& a) const
+    (Rep& r, const Rep a) const
     { _GIVARO_GFQ_NEG(r, a, GFqDom<TT>::mOne, GFqDom<TT>::_qm1) ; return r; }
 
     template<typename TT>
@@ -359,7 +359,7 @@ namespace Givaro {
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::inv
-    (Rep& r, const Rep& a) const
+    (Rep& r, const Rep a) const
     { _GIVARO_GFQ_INV(r, a, GFqDom<TT>::_qm1) ; return r; }
 
     template<typename TT>
@@ -369,13 +369,13 @@ namespace Givaro {
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::axpy
-    (Rep& r, const Rep& a, const Rep& b, const Rep& c)
+    (Rep& r, const Rep a, const Rep b, const Rep c)
 	const
     { _GIVARO_GFQ_MULADD(r,a,b,c, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ; return r; }
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::axpyin
-    (Rep& r, const Rep& a, const Rep& b) const
+    (Rep& r, const Rep a, const Rep b) const
     {
         Rep tmp = r;
         _GIVARO_GFQ_MULADD((r),a,b,tmp, (GFqDom<TT>::_qm1), (GFqDom<TT>::_plus1)) ;
@@ -385,8 +385,8 @@ namespace Givaro {
         // r <- r-a*b
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::maxpyin (Rep& r,
-                                                           const Rep& a,
-                                                           const Rep& b) const
+                                                           const Rep a,
+                                                           const Rep b) const
     {
             //   Rep tmp = r;
             //   _GIVARO_GFQ_MULSUB(r,a,b,tmp, mOne, _qm1, _plus1) ;
@@ -397,8 +397,8 @@ namespace Givaro {
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::axmyin (Rep& r,
-                                                          const Rep& a,
-                                                          const Rep& b) const
+                                                          const Rep a,
+                                                          const Rep b) const
     {
         this->maxpyin(r,a,b);
         return this->negin(r);
@@ -407,7 +407,7 @@ namespace Givaro {
         // r <- a*b-c
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::axmy
-    (Rep& r, const Rep& a, const Rep& b, const Rep& c)
+    (Rep& r, const Rep a, const Rep b, const Rep c)
         const
     {
         _GIVARO_GFQ_MUL(r,a,b, GFqDom<TT>::_qm1) ;
@@ -416,7 +416,7 @@ namespace Givaro {
 
     template<typename TT>
     inline typename GFqDom<TT>::Rep&  GFqDom<TT>::maxpy
-    (Rep& r, const Rep& a, const Rep& b, const Rep& c)
+    (Rep& r, const Rep a, const Rep b, const Rep c)
         const
     {
         _GIVARO_GFQ_MUL(r,a,b, GFqDom<TT>::_qm1) ;
@@ -436,7 +436,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::mul
-    (const size_t sz, Array r, constArray a, const Rep& b) const
+    (const size_t sz, Array r, constArray a, const Rep b) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_MUL(r[i],a[i],b, GFqDom<TT>::_qm1) ;
@@ -454,7 +454,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::div
-    (const size_t sz, Array r, constArray a, const Rep& b) const
+    (const size_t sz, Array r, constArray a, const Rep b) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_DIV(r[i],a[i],b, GFqDom<TT>::_qm1) ;
@@ -472,7 +472,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::add
-    (const size_t sz, Array r, constArray a, const Rep& b) const
+    (const size_t sz, Array r, constArray a, const Rep b) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_ADD(r[i], a[i], b, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ;
@@ -490,7 +490,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::sub
-    (const size_t sz, Array r, constArray a, const Rep& b) const
+    (const size_t sz, Array r, constArray a, const Rep b) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_SUB(r[i], a[i], b, GFqDom<TT>::mOne, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ;
@@ -517,7 +517,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::axpy
-    (const size_t sz, Array r, const Rep& a, constArray x, constArray y) const
+    (const size_t sz, Array r, const Rep a, constArray x, constArray y) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_MULADD(r[i], a, x[i], y[i], GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ;
@@ -526,7 +526,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::axpyin
-    (const size_t sz, Array r, const Rep& a, constArray x) const
+    (const size_t sz, Array r, const Rep a, constArray x) const
     {
         Rep tmp;
         for ( size_t i=sz ; --i ; ) {
@@ -537,7 +537,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::axpy
-    (const size_t sz, Array r, const Rep& a, constArray x, const Rep& y) const
+    (const size_t sz, Array r, const Rep a, constArray x, const Rep y) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_MULADD(r[i], a, x[i], y, GFqDom<TT>::_qm1, GFqDom<TT>::_plus1) ;
@@ -546,7 +546,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::axmy
-    (const size_t sz, Array r, const Rep& a, constArray x, constArray y) const
+    (const size_t sz, Array r, const Rep a, constArray x, constArray y) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_MUL(r[i], a, x[i], GFqDom<TT>::_qm1) ;
@@ -556,7 +556,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::axmy
-    (const size_t sz, Array r, const Rep& a, constArray x, const Rep& y) const
+    (const size_t sz, Array r, const Rep a, constArray x, const Rep y) const
     {
         for ( size_t i=sz ; --i ; ) {
             _GIVARO_GFQ_MUL(r[i], a, x[i], GFqDom<TT>::_qm1) ;
@@ -566,7 +566,7 @@ namespace Givaro {
 
     template<typename TT>
     inline void GFqDom<TT>::maxpyin (const size_t sz, Array r,
-                                     const Rep& a, constArray x) const
+                                     const Rep a, constArray x) const
     {
         Rep tmp;
         for ( size_t i=sz ; --i ; ) {
@@ -626,7 +626,7 @@ namespace Givaro {
     }
 
     template<typename TT>
-    inline typename GFqDom<TT>::Rep& GFqDom<TT>::reduce( Rep& r, const Rep& e) const {
+    inline typename GFqDom<TT>::Rep& GFqDom<TT>::reduce( Rep& r, const Rep e) const {
             return r = e;
     }
     template<typename TT>
@@ -766,19 +766,19 @@ namespace Givaro {
 
 
     template<typename TT>
-    inline double& GFqDom<TT>::convert (double& r, const Rep& a) const
+    inline double& GFqDom<TT>::convert (double& r, const Rep a) const
     {
         return r = (double)_log2pol[ (UT)a] ;
     }
 
     template<typename TT>
-    inline float& GFqDom<TT>::convert (float& r, const Rep& a) const
+    inline float& GFqDom<TT>::convert (float& r, const Rep a) const
     {
         return r = (float)_log2pol[ (UT)a] ;
     }
 
     template<typename TT>
-    inline std::ostream& GFqDom<TT>::write (std::ostream& o, const Rep& a) const
+    inline std::ostream& GFqDom<TT>::write (std::ostream& o, const Rep a) const
     {
         return o << _log2pol[ (UT)a] ;
     }
@@ -786,37 +786,37 @@ namespace Givaro {
 
 
     template<typename TT>
-    inline int64_t& GFqDom<TT>::convert (int64_t& r, const Rep& a) const
+    inline int64_t& GFqDom<TT>::convert (int64_t& r, const Rep a) const
     {
         return r = (int64_t)_log2pol[ (uint64_t)a] ;
     }
 
     template<typename TT>
-    inline uint64_t& GFqDom<TT>::convert (uint64_t& r, const Rep& a) const
+    inline uint64_t& GFqDom<TT>::convert (uint64_t& r, const Rep a) const
     {
         return r = (uint64_t)_log2pol[ (uint64_t)a] ;
     }
 
     template<typename TT>
-    inline int32_t& GFqDom<TT>::convert (int32_t& r, const Rep& a) const
+    inline int32_t& GFqDom<TT>::convert (int32_t& r, const Rep a) const
     {
         return r = (int32_t)_log2pol[ (UT)a] ;
     }
 
     template<typename TT>
-    inline uint32_t& GFqDom<TT>::convert (uint32_t& r, const Rep& a) const
+    inline uint32_t& GFqDom<TT>::convert (uint32_t& r, const Rep a) const
     {
         return r = (uint32_t)_log2pol[ (UT)a] ;
     }
 
     template<typename TT>
-    inline TT GFqDom<TT>::convert (const Rep& a) const
+    inline TT GFqDom<TT>::convert (const Rep a) const
     {
         return (TT)_log2pol[ (UT)a] ;
     }
 
     template<typename TT>
-    inline Integer& GFqDom<TT>::convert (Integer& r, const Rep& a) const
+    inline Integer& GFqDom<TT>::convert (Integer& r, const Rep a) const
     {
         return r = (Integer)_log2pol[ (UT)a] ;
     }
@@ -856,7 +856,7 @@ namespace Givaro {
     { return init (r, a); }
 
     template<typename TT>
-    inline typename GFqDom<TT>::Rep& GFqDom<TT>::assign( Rep& r, const Rep& a) const
+    inline typename GFqDom<TT>::Rep& GFqDom<TT>::assign( Rep& r, const Rep a) const
     { return r = a; }
 
 
@@ -922,7 +922,7 @@ namespace Givaro {
 
 
     template<typename TT> template<typename randIter>
-    inline typename GFqDom<TT>::Rep& GFqDom<TT>::random(randIter& g, Rep& r, const Rep& b) const
+    inline typename GFqDom<TT>::Rep& GFqDom<TT>::random(randIter& g, Rep& r, const Rep b) const
     {
         return random(g,r);
     }
@@ -934,7 +934,7 @@ namespace Givaro {
     }
 
     template<typename TT> template<typename randIter>
-    inline typename GFqDom<TT>::Rep& GFqDom<TT>::nonzerorandom(randIter& g, Rep& r, const Rep& b) const
+    inline typename GFqDom<TT>::Rep& GFqDom<TT>::nonzerorandom(randIter& g, Rep& r, const Rep b) const
     {
         return nonzerorandom(g,r);
     }

--- a/src/kernel/field/gfq.inl
+++ b/src/kernel/field/gfq.inl
@@ -269,11 +269,11 @@ namespace Givaro {
 	// ------------------------- Miscellaneous functions
 
     template<typename TT>
-    inline bool GFqDom<TT>::areEqual(const Rep& a, const Rep& b) const
+    inline bool GFqDom<TT>::areEqual(const Rep a, const Rep b) const
     { return a == b ; }
 
     template<typename TT>
-    inline bool GFqDom<TT>::areNEqual(const Rep& a, const Rep& b) const
+    inline bool GFqDom<TT>::areNEqual(const Rep a, const Rep b) const
     { return a != b ; }
 
     template<typename TT>
@@ -922,7 +922,7 @@ namespace Givaro {
 
 
     template<typename TT> template<typename randIter>
-    inline typename GFqDom<TT>::Rep& GFqDom<TT>::random(randIter& g, Rep& r, const Rep b) const
+    inline typename GFqDom<TT>::Rep& GFqDom<TT>::random(randIter& g, Rep& r, const Rep& b) const
     {
         return random(g,r);
     }
@@ -934,7 +934,7 @@ namespace Givaro {
     }
 
     template<typename TT> template<typename randIter>
-    inline typename GFqDom<TT>::Rep& GFqDom<TT>::nonzerorandom(randIter& g, Rep& r, const Rep b) const
+    inline typename GFqDom<TT>::Rep& GFqDom<TT>::nonzerorandom(randIter& g, Rep& r, const Rep& b) const
     {
         return nonzerorandom(g,r);
     }


### PR DESCRIPTION
A very nasty bug occurs in preparing the next release 4.1.0 and checking its integration in SageMath.
All direct test suites pass, but some indirect uses of GFqDom in Sage (mostly multivariate polynomials over GFqDom) make Sage doctests fail:
https://trac.sagemath.org/ticket/26932#comment:8

The main culprit seem to be  commit 2a4f9c42d167578163f1f0d19fb23e4178492f59 where most input argument are now passed by reference and not value as before.
The reason is likely that somewhere, someone calls a function (e.g. mul) with a duplicate argument, passed as input and output, (e.g. `mul(x,a,x)`) which according to the comments in gfq.inl should not happen.
This requirement seem very hard to enforce, and I suggest to move back to passing input argument by value (since they are word size anyway).
This PR impements the change.
I tested a release candidate of givaro with this PR in sage, and the bugs vanish. 