### PR TITLE
modular-implem: add attributes to ease discriminate against integral/floating type

### DIFF
--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -15,6 +15,8 @@
 #ifndef __GIVARO_modular_implem_H
 #define __GIVARO_modular_implem_H
 
+#include <type_traits>
+
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
@@ -51,6 +53,11 @@ namespace Givaro {
         using Storage_t = _Storage_t;
         using Compute_t = _Compute_t;
         using Residu_t = _Residu_t;
+
+        using is_elt_integral = std::is_integral<Element>;
+        static constexpr bool is_elt_integral_v = is_elt_integral::value;
+        using is_elt_floating_point = std::is_floating_point<Element>;
+        static constexpr bool is_elt_floating_point_v = is_elt_floating_point::value;
 
         // ----- Exported Types and constantes
         enum { size_rep = sizeof(Residu_t) };


### PR DESCRIPTION
The goal of this PR is to ease writing enable_if statements to differentiate between Modular using integral or floating type for Element.

Before we would need to write something like:
```cpp
template <class M, typename std::enable_if<std::is_integral<typename M::Element>::value>::type>
...
```
With this PR we could write
```cpp
template <class M, typename std::enable_if<M::is_integral_v>::type>
...
```
which is, in my opinion, a little bit easier to write and read.