### PR TITLE
Switch from gettimeofday to C11 timespec_get.

### DIFF
--- a/src/kernel/system/givconfig.h
+++ b/src/kernel/system/givconfig.h
@@ -282,14 +282,15 @@ typedef unsigned  __GIVARO_INT64     uint64_t;
 #define _SYS_UNDEF 0
 #define _SYS_MACOS 1
 
-
-
 // ==========================================================================
 // -- System variable
 #ifndef GIVARO_SYS
-#define GIVARO_SYS _SYS_UNDEF
+#  ifdef __APPLE__
+#    define GIVARO_SYS _SYS_MACOS
+#  else
+#    define GIVARO_SYS _SYS_UNDEF
+#  endif
 #endif
-
 
 // ==========================================================================
 // -- Misc features. Should be deleted

--- a/src/kernel/system/givtimer.C
+++ b/src/kernel/system/givtimer.C
@@ -37,9 +37,9 @@ namespace Givaro {
 #if (GIVARO_SYS == _SYS_MACOS)
         return clock() ;
 #else
-        struct timeval tp;
-        gettimeofday(&tp, 0) ;
-        return static_cast<int64_t>(tp.tv_usec);
+        struct timespec ts;
+        timespec_get(&ts, TIME_UTC);
+        return static_cast<int64_t>(ts.tv_nsec);
 #endif
     }
 


### PR DESCRIPTION
Do we still need to use 'clock' on MACOS ?