### PR TITLE
Avoid temporary creation in Montgomery::convert.

### DIFF
--- a/src/kernel/ring/montgomery-ruint.h
+++ b/src/kernel/ring/montgomery-ruint.h
@@ -137,7 +137,7 @@ namespace Givaro
 
         // ----- Convert and reduce
         template<typename T> T& convert(T& r, const Element& a) const
-        { Element tmp; return r = Caster<T>(mg_reduc(tmp, a)); }
+        { Element tmp; return Caster<T>(r, mg_reduc(tmp, a)); }
 
         Element& reduce (Element& x, const Element& y) const
         { x = y % _p; return x; }


### PR DESCRIPTION
While investigating a problem with fflas-ffpack, I built both it and givaro with -fsanitize=address.  This turned up a small memory leak in givaro.  The one argument form of Caster creates a stack object, then returns that object by copy.  On the calling side, a temporary is created to hold the return value.  The code in Montgomery::convert copies, rather than moves, the contents of the temporary into r, thereby leaking the memory pointed to by the temporary.  This commit uses the two argument form of Caster to avoid creating the temporary in the first place.