### PR TITLE
 modular-implem: modular-implem: add attributes to ease discriminate against integral/floating type (cont'd)

### DIFF
--- a/src/kernel/ring/modular-extended.h
+++ b/src/kernel/ring/modular-extended.h
@@ -10,6 +10,8 @@
 #ifndef __GIVARO_MODULAR_EXTENDED_H
 #define __GIVARO_MODULAR_EXTENDED_H
 
+#include <type_traits>
+
 #include "givaro/givconfig.h"
 
 #include "givaro/givranditer.h"
@@ -37,6 +39,11 @@ namespace Givaro{
         using Compute_t = _Element;
         typedef uint64_t Residu_t;
         enum { size_rep = sizeof(Residu_t) };
+
+        using is_elt_integral = std::false_type;
+        static constexpr bool is_elt_integral_v = false;
+        using is_elt_floating_point = std::true_type;
+        static constexpr bool is_elt_floating_point_v = true;
 
     private:
         // Verkampt Split


### PR DESCRIPTION
This PR is a follow-up of PR #118.
In #118, some attributes were added to the Modular class but I forgot to add them for ModularExtended. This is done in this PR.