### PR TITLE
Clean / refactor rational reconstruction

### DIFF
--- a/src/kernel/rational/givrational.h
+++ b/src/kernel/rational/givrational.h
@@ -179,7 +179,7 @@ namespace Givaro {
             forcereduce : must return a reduced fraction num/den
             recurs : tries to augment the given bound k if failure
         */
-        bool ratrecon(const Integer& f, const Integer& m, const Integer& k, 
+        bool ratrecon(const Integer& f, const Integer& m, const Integer& k,
                       bool forcereduce = true, bool recurs = false ) ;
     public:
 
@@ -192,7 +192,7 @@ namespace Givaro {
 
         static bool RationalReconstruction(
             Integer& num, Integer& den, const Integer& f, const Integer& m,
-            const Integer& numbound, 
+            const Integer& numbound,
             bool forcereduce = true, bool recursive = true );
 
         // - exportation of the module

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -19,20 +19,20 @@ namespace Givaro {
     // either num = den f mod m     (1)
     // or     num den^-1 = f mod m  (2)
     // verifying |num|<k and 0 <= den <= m/k
-    // 
+    //
     // List of remarks :
     // * it seems that forcereduce tells whether we solve (1) or (2)
     //   -> change variable name ?
-    // * Rename, refactor e.g. 
+    // * Rename, refactor e.g.
     //     ratrecon(7 args) ~= RationalReconstruction(7 args)
     //     rename ratrecon(5 args) or remove from interface ?
-    // * What does RationalReconstruction(7 args) do 
+    // * What does RationalReconstruction(7 args) do
     //   that ratrecon(7 args) do not do
     // * What do the following tests achieve ? Related to a bug ?
     //     if (num == 0)
     //     if ((f % m) == 0)
     // * Should the recursive aspect bool recurs be done by ratrecon ?
- 
+
     bool Rational::ratrecon(
         Integer& num, Integer& den, const Integer& f, const Integer& m,
         const Integer& k, bool forcereduce, bool recurs)

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -69,25 +69,29 @@ namespace Givaro {
         }
 
         if (num == 0) {
-            if (!recurs)
-                std::cerr
-                    << "*** Error *** There exists no rational reconstruction of "
-                    << f
-                    << " modulo "
-                    << m
-                    << " with |numerator| < "
-                    << k
-                    << std::endl
-                    << "*** Error *** But "
-                    << num
-                    << " = "
-                    << den
-                    << " * "
-                    << f
-                    << " modulo "
-                    << m
-                    << std::endl;
-            return false;
+            if ((f % m) == 0) {
+                return true;
+            } else  {
+                if (!recurs)
+                    std::cerr
+                        << "*** Error *** There exists no rational reconstruction of "
+                        << f
+                        << " modulo "
+                        << m
+                        << " with |numerator| < "
+                        << k
+                        << std::endl
+                        << "*** Error *** But "
+                        << num
+                        << " = "
+                        << den
+                        << " * "
+                        << f
+                        << " modulo "
+                        << m
+                        << std::endl;
+                return false;
+            }
         }
 
         if (forcereduce) {

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -68,32 +68,6 @@ namespace Givaro {
             den = t1;
         }
 
-        if (num == 0) {
-            if ((f % m) == 0) {
-                return true;
-            } else {
-                if (!recurs)
-                    std::cerr
-                        << "*** Error *** There exists no rational reconstruction of "
-                        << f
-                        << " modulo "
-                        << m
-                        << " with |numerator| < "
-                        << k
-                        << std::endl
-                        << "*** Error *** But "
-                        << num
-                        << " = "
-                        << den
-                        << " * "
-                        << f
-                        << " modulo "
-                        << m
-                        << std::endl;
-                return false;
-            }
-        }
-
         if (forcereduce) {
 
                 // (ii)
@@ -108,6 +82,33 @@ namespace Givaro {
                       << "k:=" << k << ';'
                       << std::endl;
 #endif
+
+                if (num == 0) {
+                    if ((f % m) == 0) {
+                        return true;
+                    } else {
+                        if (!recurs)
+                            std::cerr
+                                << "*** Error *** There exists no rational reconstruction of "
+                                << f
+                                << " modulo "
+                                << m
+                                << " with |numerator| < "
+                                << k
+                                << std::endl
+                                << "*** Error *** But "
+                                << num
+                                << " = "
+                                << den
+                                << " * "
+                                << f
+                                << " modulo "
+                                << m
+                                << std::endl;
+                        return false;
+                    }
+                }
+
                 q = r0;
                 q += r1;
                 q -= k;

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -71,7 +71,7 @@ namespace Givaro {
         if (num == 0) {
             if ((f % m) == 0) {
                 return true;
-            } else  {
+            } else {
                 if (!recurs)
                     std::cerr
                         << "*** Error *** There exists no rational reconstruction of "

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -176,7 +176,7 @@ namespace Givaro {
      bool recurs ) {
         bool res = this->ratrecon(f,m,k,Rational::flags,recurs);
         if (recurs)
-            for( Integer newk = k + 1; (!res) && (newk<f) ; ++newk)
+            for( Integer newk = k + 1; (!res) && (newk<f) ; newk<<=1)
                 res = this->ratrecon(f,m,newk,Rational::flags,true);
     }
 
@@ -204,7 +204,7 @@ namespace Givaro {
         else {
             res = ratrecon(a,b,x,m,k, forcereduce, recursive);
             if (recursive)
-                for( Integer newk = k + 1; (!res) && (newk<f) ; ++newk)
+                for( Integer newk = k + 1; (!res) && (newk<f) ; newk<<=1)
                     res = ratrecon(a,b,x,m,newk,forcereduce, true);
         }
         return res;

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -16,13 +16,13 @@ namespace Givaro {
 
 
     bool Rational::ratrecon(
-        Integer& num, Integer& den, const Integer& f, const Integer& m, 
+        Integer& num, Integer& den, const Integer& f, const Integer& m,
         const Integer& k, bool forcereduce, bool recurs)
     {
 
 #ifdef GIVARO_RATRECON_DEBUG
-        std::clog << "RatRecon : " << f << " mod " << m 
-                  << ", num bounded by: " << k 
+        std::clog << "RatRecon : " << f << " mod " << m
+                  << ", num bounded by: " << k
                   << ", reducedfraction: " << forcereduce
                   << ", expandboundwhenfailure: " << recurs
                   << std::endl;
@@ -48,12 +48,12 @@ namespace Givaro {
             q /= r1;    // r0/r1
 
             u = r1;
-            r1 = r0;  	// r1 <-- r0
+            r1 = r0;	// r1 <-- r0
             r0 = u;	    // r0 <-- r1
             Integer::maxpyin(r1,u,q);
 
             u = t1;
-            t1 = t0;  	// r1 <-- r0
+            t1 = t0;	// r1 <-- r0
             t0 = u;	    // r0 <-- r1
             Integer::maxpyin(t1,u,q);
         }
@@ -108,14 +108,14 @@ namespace Givaro {
                 q += r1;
                 q -= k;
                 q /= r1;
-                
+
 #ifdef GIVARO_RATRECON_DEBUG
             std::clog << "q:=" << q  << ';' << std::endl;
 #endif
-                
+
                 r0 -= q * r1;
                 t0 -= q * t1;
-                
+
                 if (t0 < 0) {
                     num = -r0;
                     den = -t0;
@@ -123,7 +123,7 @@ namespace Givaro {
                     num = r0;
                     den = t0;
                 }
-                
+
                 if (t0 > m/k) {
                     if (!recurs)
                         std::cerr
@@ -163,16 +163,16 @@ namespace Givaro {
 #endif
         return true;
     }
-    
+
     bool Rational::ratrecon
-    (const Integer& f, const Integer& m, const Integer& k, 
+    (const Integer& f, const Integer& m, const Integer& k,
      bool forcereduce, bool recurs) {
         return Rational::ratrecon(this->num, this->den,
                                   f,m,k,forcereduce,recurs);
-    }        
+    }
 
     Rational::Rational
-    (const Integer& f, const Integer& m, const Integer& k, 
+    (const Integer& f, const Integer& m, const Integer& k,
      bool recurs ) {
         bool res = this->ratrecon(f,m,k,Rational::flags,recurs);
         if (recurs)
@@ -196,7 +196,7 @@ namespace Givaro {
             if (x>m)
                 x %= m;
         }
-        
+
         if (x == 0) {
             a = 0;
             b = 1;
@@ -209,17 +209,17 @@ namespace Givaro {
         }
         return res;
     }
-    
+
     bool Rational::RationalReconstruction
     (Integer& a, Integer& b, const Integer& x, const Integer& m) {
         return ratrecon(a, b, x, m, Givaro::sqrt(m), true, true);
     }
     bool Rational::RationalReconstruction
-    (Integer& a, Integer& b, const Integer& x, const Integer& m, 
+    (Integer& a, Integer& b, const Integer& x, const Integer& m,
      const Integer& a_bound, const Integer& b_bound) {
         Integer bound = x/b_bound;
-        ratrecon(a,b,x,m, 
-                 (bound>a_bound?bound:a_bound), 
+        ratrecon(a,b,x,m,
+                 (bound>a_bound?bound:a_bound),
                  true, false);
         return b <= b_bound;
     }

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -28,9 +28,6 @@ namespace Givaro {
     //     rename ratrecon(5 args) or remove from interface ?
     // * What does RationalReconstruction(7 args) do
     //   that ratrecon(7 args) do not do
-    // * What do the following tests achieve ? Related to a bug ?
-    //     if (num == 0)
-    //     if ((f % m) == 0)
     // * Should the recursive aspect bool recurs be done by ratrecon ?
 
     bool Rational::ratrecon(

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -9,7 +9,6 @@
 // $Id: givratreconstruct.C,v 1.4 2010-04-12 15:54:39 jgdumas Exp $
 // ==========================================================================
 // Description:
-
 #include "givaro/givrational.h"
 #include <iostream>
 
@@ -52,7 +51,6 @@ namespace Givaro {
             r1 = r0;  	// r1 <-- r0
             r0 = u;	    // r0 <-- r1
             Integer::maxpyin(r1,u,q);
-            if (r1 == 0) break;
 
             u = t1;
             t1 = t0;  	// r1 <-- r0
@@ -68,6 +66,28 @@ namespace Givaro {
         } else {
             num = r1;
             den = t1;
+        }
+
+        if (num == 0) {
+            if (!recurs)
+                std::cerr
+                    << "*** Error *** There exists no rational reconstruction of "
+                    << f
+                    << " modulo "
+                    << m
+                    << " with |numerator| < "
+                    << k
+                    << std::endl
+                    << "*** Error *** But "
+                    << num
+                    << " = "
+                    << den
+                    << " * "
+                    << f
+                    << " modulo "
+                    << m
+                    << std::endl;
+            return false;
         }
 
         if (forcereduce) {

--- a/src/kernel/rational/givratreconstruct.C
+++ b/src/kernel/rational/givratreconstruct.C
@@ -14,7 +14,25 @@
 
 namespace Givaro {
 
-
+    // Let f,m \in Z
+    // Find num, den such that
+    // either num = den f mod m     (1)
+    // or     num den^-1 = f mod m  (2)
+    // verifying |num|<k and 0 <= den <= m/k
+    // 
+    // List of remarks :
+    // * it seems that forcereduce tells whether we solve (1) or (2)
+    //   -> change variable name ?
+    // * Rename, refactor e.g. 
+    //     ratrecon(7 args) ~= RationalReconstruction(7 args)
+    //     rename ratrecon(5 args) or remove from interface ?
+    // * What does RationalReconstruction(7 args) do 
+    //   that ratrecon(7 args) do not do
+    // * What do the following tests achieve ? Related to a bug ?
+    //     if (num == 0)
+    //     if ((f % m) == 0)
+    // * Should the recursive aspect bool recurs be done by ratrecon ?
+ 
     bool Rational::ratrecon(
         Integer& num, Integer& den, const Integer& f, const Integer& m,
         const Integer& k, bool forcereduce, bool recurs)

--- a/tests/test-ratrecon.C
+++ b/tests/test-ratrecon.C
@@ -30,7 +30,7 @@ template<class RingDomain, class BoundingStathme>
 int TestRR(RingDomain& RDom, GivRandom& generator,
            const typename RingDomain::Element& M,
            const typename RingDomain::Element& P,
-           const typename RingDomain::Element& Q, 
+           const typename RingDomain::Element& Q,
            const BoundingStathme& d) {
 //     RDom.write(std::clog << "M:= ", M) << ';' << std::endl;
 //     RDom.write(std::clog << "P:= ", P) << ';' << std::endl;
@@ -105,7 +105,7 @@ int TestRatRR(GivRandom& generator, const size_t b) {
 
     return TestRR(IntDom, generator, M, P, Q, P+1);
 }
- 
+
 
 
 template<class PDomain>
@@ -133,7 +133,6 @@ int TestPolRR(PDomain& PolDom, GivRandom& generator, const Degree d) {
 
     return TestRR(PolDom, generator, M, P, Q, d);
 }
- 
 
 
 int main(int argc, char ** argv)
@@ -146,6 +145,22 @@ int main(int argc, char ** argv)
     Integer::seeding((unsigned long)seed);
     GivRandom generator((unsigned long)seed);
 
+
+//     RDom.write(std::clog << "R3:= ", R) << ';' << std::endl;
+    ZRing<Integer> IntDom;
+    Integer R(75), M(250), A, B, d1(17), d2(26);
+
+    bool success = true;
+
+        // Should be impossible;
+    bool reconstructed = IntDom.ratrecon(A,B,R,M,d1);
+    success &= (!reconstructed);
+
+        // Now it should be ok
+    reconstructed = IntDom.ratrecon(A,B,R,M,d2);
+    success &= (reconstructed && (IntDom.isZero((R*B-A)%M)));
+
+
     typedef Modular<int64_t> Field;
     typedef Poly1Dom< Field, Dense > PolyZpz;
     typedef FracDom<PolyZpz> FracZpz;
@@ -154,14 +169,13 @@ int main(int argc, char ** argv)
     Field F101(101);
     Field F2(2);
     Field F65521(65521);
-    bool success = true;
-    
+
     {
         for(size_t loop=0; loop<100; ++loop)
             for (size_t b=10; b<10000; b <<=1)
                 success &= (! TestRatRR(generator, b) );
     }
-    
+
 
 
     {

--- a/tests/test-ratrecon.C
+++ b/tests/test-ratrecon.C
@@ -160,6 +160,9 @@ int main(int argc, char ** argv)
     reconstructed = IntDom.ratrecon(A,B,R,M,d2);
     success &= (reconstructed && (IntDom.isZero((R*B-A)%M)));
 
+    reconstructed = IntDom.ratrecon(A,B,R,M,d1,false);
+    success &= (reconstructed && (IntDom.isZero((R*B-A)%M)));
+
 
     typedef Modular<int64_t> Field;
     typedef Poly1Dom< Field, Dense > PolyZpz;


### PR DESCRIPTION
* it seems that forcereduce tells whether we solve (num = den f mod m) or (num den^-1 = f mod m)
  -> change variable name ?
* Rename, refactor e.g.
    ratrecon(7 args) ~= RationalReconstruction(7 args)
    rename ratrecon(5 args) or remove from interface ?
* What does RationalReconstruction(7 args) do
  that ratrecon(7 args) do not do
* Should the recursive aspect bool recurs be done by ratrecon ?