### PR TITLE
Have a dedicated MaxCardinality for FFLAS

### DIFF
--- a/src/kernel/ring/modular-balanced-double.h
+++ b/src/kernel/ring/modular-balanced-double.h
@@ -75,7 +75,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return Caster(p,_p); }
         template<class T> inline T& cardinality(T& p) const { return Caster(p,_p); }
 
-        static inline Residu_t maxCardinality() { return 134217727; } // 2^12.5
+        static inline Residu_t maxCardinality() { return 189812531; } // p=2^27.5 s.t. a*b+c fits in double, with abs(a,b,c) < (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 134217729; } // p = 2^27 + 1 s.t. a*b+c*d fits in double, with abs(a,b,c,d) < (p-1)/2
         static inline Residu_t minCardinality() { return 3.f; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-double.h
+++ b/src/kernel/ring/modular-balanced-double.h
@@ -75,8 +75,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return Caster(p,_p); }
         template<class T> inline T& cardinality(T& p) const { return Caster(p,_p); }
 
-        static inline Residu_t maxCardinality() { return 189812531; } // p=2^27.5 s.t. a*b+c fits in double, with abs(a,b,c) < (p-1)/2
-        static inline Residu_t maxFFLASCardinality() { return 134217729; } // p = 2^27 + 1 s.t. a*b+c*d fits in double, with abs(a,b,c,d) < (p-1)/2
+        static inline Residu_t maxCardinality() { return 189812531; } // p=2^27.5 s.t. a*b+c fits in double, with abs(a,b,c) <= (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 134217729; } // p = 2^27 + 1 s.t. a*b+c*d fits in double, with abs(a,b,c,d) <= (p-1)/2
         static inline Residu_t minCardinality() { return 3.f; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-float.h
+++ b/src/kernel/ring/modular-balanced-float.h
@@ -75,7 +75,7 @@ namespace Givaro
         template<class T> inline T& cardinality(T& p) const { return Caster(p,_p); }
 
         static inline Residu_t maxCardinality() { return 8192.f; } // p=2^13 s.t. a*b+c fits in float, with abs(a,b,c) < (p-1)/2
-        static inline Residu_t maxFFLASCardinality() { return 5794.f; } // p \approx 2^12.5 s.t. a*b+c*d fits in float, with abs(a,b,c,d) < (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 5793.f; } // p \approx 2^12.5 s.t. a*b+c*d fits in float, with abs(a,b,c,d) < (p-1)/2
         static inline Residu_t minCardinality() { return 3.f; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-float.h
+++ b/src/kernel/ring/modular-balanced-float.h
@@ -74,7 +74,7 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return Caster(p,_p); }
         template<class T> inline T& cardinality(T& p) const { return Caster(p,_p); }
 
-        static inline Residu_t maxCardinality() { return 8192; } // p=2^13 s.t. a*b+c fits in float, with abs(a,b,c) < (p-1)/2
+        static inline Residu_t maxCardinality() { return 8192.f; } // p=2^13 s.t. a*b+c fits in float, with abs(a,b,c) < (p-1)/2
         static inline Residu_t maxFFLASCardinality() { return 5794.f; } // p \approx 2^12.5 s.t. a*b+c*d fits in float, with abs(a,b,c,d) < (p-1)/2
         static inline Residu_t minCardinality() { return 3.f; }
 

--- a/src/kernel/ring/modular-balanced-float.h
+++ b/src/kernel/ring/modular-balanced-float.h
@@ -74,7 +74,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return Caster(p,_p); }
         template<class T> inline T& cardinality(T& p) const { return Caster(p,_p); }
 
-        static inline Residu_t maxCardinality() { return 5791.f; } // 2^12.5
+        static inline Residu_t maxCardinality() { return 8192; } // p=2^13 s.t. a*b+c fits in float, with abs(a,b,c) < (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 5794.f; } // p \approx 2^12.5 s.t. a*b+c*d fits in float, with abs(a,b,c,d) < (p-1)/2
         static inline Residu_t minCardinality() { return 3.f; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-float.h
+++ b/src/kernel/ring/modular-balanced-float.h
@@ -74,8 +74,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return Caster(p,_p); }
         template<class T> inline T& cardinality(T& p) const { return Caster(p,_p); }
 
-        static inline Residu_t maxCardinality() { return 8192.f; } // p=2^13 s.t. a*b+c fits in float, with abs(a,b,c) < (p-1)/2
-        static inline Residu_t maxFFLASCardinality() { return 5793.f; } // p \approx 2^12.5 s.t. a*b+c*d fits in float, with abs(a,b,c,d) < (p-1)/2
+        static inline Residu_t maxCardinality() { return 8192.f; } // p=2^13 s.t. a*b+c fits in float, with abs(a,b,c) <= (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 5793.f; } // p \approx 2^12.5 s.t. a*b+c*d fits in float, with abs(a,b,c,d) <= (p-1)/2
         static inline Residu_t minCardinality() { return 3.f; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-int32.h
+++ b/src/kernel/ring/modular-balanced-int32.h
@@ -71,7 +71,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return p = _p; }
         template<class T> inline T& cardinality(T& p) const { return p = _p; }
 
-        static inline Residu_t maxCardinality() { return 92681; } // 2^16.5
+        static inline Residu_t maxCardinality() { return 131072; } // p=2^17 s.t. a*b+c fits in int32_t, with abs(a,b,c) < (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 92682; } // p\approx 2^16.5 s.t. a*b+c*d fits in int32_t, with abs(a,b,c,d) < (p-1)/2
         static inline Residu_t minCardinality() { return 3; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-int32.h
+++ b/src/kernel/ring/modular-balanced-int32.h
@@ -71,8 +71,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return p = _p; }
         template<class T> inline T& cardinality(T& p) const { return p = _p; }
 
-        static inline Residu_t maxCardinality() { return 131072; } // p=2^17 s.t. a*b+c fits in int32_t, with abs(a,b,c) < (p-1)/2
-        static inline Residu_t maxFFLASCardinality() { return 92682; } // p\approx 2^16.5 s.t. a*b+c*d fits in int32_t, with abs(a,b,c,d) < (p-1)/2
+        static inline Residu_t maxCardinality() { return 131072; } // p=2^17 s.t. a*b+c fits in int32_t, with abs(a,b,c) <= (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 92682; } // p\approx 2^16.5 s.t. a*b+c*d fits in int32_t, with abs(a,b,c,d) <= (p-1)/2
         static inline Residu_t minCardinality() { return 3; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-int64.h
+++ b/src/kernel/ring/modular-balanced-int64.h
@@ -70,8 +70,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return p = _p; }
         template<class T> inline T& cardinality(T& p) const { return p = _p; }
 
-        static inline Residu_t maxCardinality() { return 8589934592; } // p=2^33 s.t. a*b+c fits in int64_t, with abs(a,b,c) < (p-1)/2
-        static inline Residu_t maxFFLASCardinality() { return 6074001000; } // p\approx 2^32.5 s.t. a*b+c*d fits in int64_t, with abs(a,b,c,d) < (p-1)/2
+        static inline Residu_t maxCardinality() { return 8589934592; } // p=2^33 s.t. a*b+c fits in int64_t, with abs(a,b,c) <= (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 6074001000; } // p\approx 2^32.5 s.t. a*b+c*d fits in int64_t, with abs(a,b,c,d) <= (p-1)/2
         static inline Residu_t minCardinality() { return 3; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-balanced-int64.h
+++ b/src/kernel/ring/modular-balanced-int64.h
@@ -70,7 +70,8 @@ namespace Givaro
         template<class T> inline T& characteristic(T& p) const { return p = _p; }
         template<class T> inline T& cardinality(T& p) const { return p = _p; }
 
-        static inline Residu_t maxCardinality() { return 6074000999; } // 2^32.5
+        static inline Residu_t maxCardinality() { return 8589934592; } // p=2^33 s.t. a*b+c fits in int64_t, with abs(a,b,c) < (p-1)/2
+        static inline Residu_t maxFFLASCardinality() { return 6074001000; } // p\approx 2^32.5 s.t. a*b+c*d fits in int64_t, with abs(a,b,c,d) < (p-1)/2
         static inline Residu_t minCardinality() { return 3; }
 
         // ----- Checkers

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -131,7 +131,7 @@ namespace Givaro {
         // --         uintN_t  | uint2N_t  | 2^N - 1 ; because 2^N can not be stored on Residu_t
         // --         float    |  float    | 4096: 2^12
         // --         double   |  double   | 94906266: floor(2^26 sqrt(2) + 1/2)
-        // --         float    |  double   | 16777217: 2^24
+        // --         float    |  double   | 16777216: 2^24
         // --         Integer  |  Integer  | None
         // --         ruint<K> |  ruint<K> | ruint<K>::maxModulus (= 2^(2^K))
         // --         ruint<K> | ruint<K+1>| ruint<K>::maxCardinality/2
@@ -157,10 +157,10 @@ namespace Givaro {
         }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && IS_SAME(S, Compute_t))
-        static Residu_t maxCardinality() { return 4096; }
+        static Residu_t maxCardinality() { return 4096.f; }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && !IS_SAME(S, Compute_t))
-        static Residu_t maxCardinality() { return 16777216; }
+        static Residu_t maxCardinality() { return 16777216.f; }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, double))
         static Residu_t maxCardinality() { return 94906266; }

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -131,10 +131,10 @@ namespace Givaro {
         // --         uintN_t  | uint2N_t  | 2^N - 1 ; because 2^N can not be stored on Residu_t
         // --         float    |  float    | 4096: 2^12
         // --         double   |  double   | 94906266: floor(2^26 sqrt(2) + 1/2)
-        // --         float    |  double   | 16777216: 2^24
+        // --         float    |  double   | 16777217: 2^24
         // --         Integer  |  Integer  | None
-        // --         ruint<K> |  ruint<K> | ruint<K>::maxCardinality()
-        // --         ruint<K> | ruint<K+1>| (ruint<K+1>::maxCardinality()-1).Low/2
+        // --         ruint<K> |  ruint<K> | ruint<K>::maxModulus (= 2^(2^K))
+        // --         ruint<K> | ruint<K+1>| ruint<K>::maxCardinality/2
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_INT(S) && (sizeof(S) == sizeof(Compute_t)))
         static Residu_t maxCardinality() {
@@ -177,12 +177,76 @@ namespace Givaro {
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, is_smaller_ruint<S, Compute_t>::value)
         static Residu_t maxCardinality()
         {
-            Residu_t max;
-            return RecInt::fill_with_1(max) >> 1;
+            return Residu_t::maxCardinality() >> 1;
         }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, !IS_INT(S) && !IS_FLOAT(S) && !IS_SAME(S, Integer) && !is_ruint<S>::value)
         static Residu_t maxCardinality() {
+            return -1;
+        }
+
+        // -- maxFFLASCardinality
+        // -- Goal: being able to store in Compute_t the result of x*y + z*t
+        // --       when x, y, z and t belong to Storage_t
+        // -- => Storage_t must store integers up to maxCardinality-1
+        // -- => Compute_t must store integers up to 2(p-1)(p-1) where p = maxCardinality
+
+        // -- Rules: Storage_t | Compute_t | maxCardinality
+        // --        ----------+-----------+---------------
+        // --        (u)intN_t |  uintN_t  | 2^((N-1)/2)
+        // --          intN_t  | uint2N_t  | 2^(N-1) - 1
+        // --         uintN_t  | uint2N_t  | 2^(N-1)
+        // --         float    |  float    | 2897: floor(2^11 x sqrt(2)+1)
+        // --         double   |  double   | 67108865 : 2^26 + 1
+        // --         float    |  double   | 16777217: 2^24 +1
+        // --         Integer  |  Integer  | None
+        // --         ruint<K> |  ruint<K> | ruint<K>::maxModulus (= 2^(2^K))
+        // --         ruint<K> | ruint<K+1>| ruint<K>::maxCardinality()/2
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_INT(S) && (sizeof(S) == sizeof(Compute_t)))
+        static Residu_t maxFFLASCardinality() {
+            std::size_t k = sizeof(S);
+            return static_cast<Residu_t> ( (1 << (k << 2)) * M_SQRT1_2) ; // 2^(N-1/2) with N = bitsize(Storage_t)
+        }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SINT(S) && (2*sizeof(S) == sizeof(Compute_t)))
+        static Residu_t maxFFLASCardinality() {
+            Residu_t repunit = ~0;
+            return repunit >> 1; // 2^(N-1)-1 with N = bitsize(Storage_t)
+        }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_UINT(S) && (2*sizeof(S) == sizeof(Compute_t)))
+        static Residu_t maxFFLASCardinality() {
+            std::size_t k = sizeof(S);
+            return (Residu_t)1 << ((k << 3) -1); // 2^(N-1) with N = bitsize(Storage_t)
+        }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && IS_SAME(S, Compute_t))
+        static Residu_t maxFFLASCardinality() { return 2897; }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && !IS_SAME(S, Compute_t))
+        static Residu_t maxFFLASCardinality() { return 16777217; }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, double))
+        static Residu_t maxFFLASCardinality() { return 67108865; }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, Integer))
+        static Residu_t maxFFLASCardinality() { return -1; }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, is_same_ruint<S, Compute_t>::value)
+        static Residu_t maxFFLASCardinality()
+        {
+            return S::maxModulus();
+        }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, is_smaller_ruint<S, Compute_t>::value)
+        static Residu_t maxFFLASCardinality()
+        {
+            return Residu_t::maxCardinality() >> 1;
+        }
+
+        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, !IS_INT(S) && !IS_FLOAT(S) && !IS_SAME(S, Integer) && !is_ruint<S>::value)
+        static Residu_t maxFFLASCardinality() {
             return -1;
         }
 

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -126,9 +126,9 @@ namespace Givaro {
 
         // -- Rules: Storage_t | Compute_t | maxCardinality
         // --        ----------+-----------+---------------
-        // --        (u)intN_t |  uintN_t  | 2^(N/2) - 1: could be 2^(N/2) but provokes errors in fflas-ffpack
+        // --        (u)intN_t |  uintN_t  | 2^(N/2)
         // --          intN_t  | uint2N_t  | 2^(N-1) - 1
-        // --         uintN_t  | uint2N_t  | 2^N - 1
+        // --         uintN_t  | uint2N_t  | 2^N - 1 ; because 2^N can not be stored on Residu_t
         // --         float    |  float    | 4096: 2^12
         // --         double   |  double   | 94906266: floor(2^26 sqrt(2) + 1/2)
         // --         float    |  double   | 16777216: 2^24
@@ -139,9 +139,9 @@ namespace Givaro {
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_INT(S) && (sizeof(S) == sizeof(Compute_t)))
         static Residu_t maxCardinality() {
             std::size_t k = sizeof(S);
-            Residu_t repunit = ~0;
-            return repunit >> (k << 2);
-            //return (Residu_t)1 << (k << 2); // 2^(N/2) with N = bitsize(Storage_t)
+            // Residu_t repunit = ~0;
+            // return repunit >> (k << 2);
+            return (Residu_t)1 << (k << 2); // 2^(N/2) with N = bitsize(Storage_t)
         }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SINT(S) && (2*sizeof(S) == sizeof(Compute_t)))

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -206,7 +206,7 @@ namespace Givaro {
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_INT(S) && (sizeof(S) == sizeof(Compute_t)))
         static Residu_t maxFFLASCardinality() {
             std::size_t k = sizeof(S);
-            return static_cast<Residu_t> ( (1 << (k << 2)) * M_SQRT1_2) ; // 2^(N-1/2) with N = bitsize(Storage_t)
+            return static_cast<Residu_t> ( (1ul << (k << 2)) * M_SQRT1_2) ; // 2^(N/2-1/2) with N = bitsize(Storage_t)
         }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SINT(S) && (2*sizeof(S) == sizeof(Compute_t)))
@@ -222,13 +222,13 @@ namespace Givaro {
         }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && IS_SAME(S, Compute_t))
-        static Residu_t maxFFLASCardinality() { return 2897; }
+        static Residu_t maxFFLASCardinality() { return 2897.f; }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float) && !IS_SAME(S, Compute_t))
-        static Residu_t maxFFLASCardinality() { return 16777217; }
+        static Residu_t maxFFLASCardinality() { return 16777217.f; }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, double))
-        static Residu_t maxFFLASCardinality() { return 67108865; }
+        static Residu_t maxFFLASCardinality() { return 67108865.; }
 
         __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, Integer))
         static Residu_t maxFFLASCardinality() { return -1; }

--- a/tests/test-ffarith.C
+++ b/tests/test-ffarith.C
@@ -6,6 +6,7 @@
 // see the COPYRIGHT file for more details.
 
 #include <iostream>
+#include <iomanip>
 
 #include "test-fieldarith.h"
 #include <givaro/modular.h>
@@ -29,6 +30,7 @@ int main(int argc, char ** argv)
 #ifdef GIVARO_DEBUG
     std::cerr << "seed: " << seed << std::endl;
 #endif
+    std::cerr<<std::setprecision(17);
     Integer::seeding((uint64_t)seed);
     RecInt::srand(seed);
 

--- a/tests/test-fieldarith.h
+++ b/tests/test-fieldarith.h
@@ -180,16 +180,15 @@ int TestOneField(const Field& F, const typename Field::Element& first)
     F.mul(a_,a,a); // a_ = a*a
     F.mul(b_,b,b); // b_ = b*b
     F.sub(e_,a_,b_); // e_ = a_ - b_
-
-    //         F.write(std::cerr) << std::endl;
-    //         F.write(std::cerr << "a:=", a) << ';' << std::endl;
-    //         F.write(std::cerr << "b:=", b) << ';' << std::endl;
-    //         F.write(std::cerr << "c:=", c) << ';' << std::endl;
-    //         F.write(std::cerr << "d:=", d) << ';' << std::endl;
-    //         F.write(std::cerr << "e:=", e) << ';' << std::endl;
-    //         F.write(std::cerr << "e_:=", e_) << ';' << std::endl;
-    //         F.write(std::cerr << "a_:=", a_) << ';' << std::endl;
-    //         F.write(std::cerr << "b_:=", b_) << ';' << std::endl;
+    // F.write(std::cerr) << std::endl;
+    // F.write(std::cerr << "a:=", a) << ';' << std::endl;
+    // F.write(std::cerr << "b:=", b) << ';' << std::endl;
+    // F.write(std::cerr << "c:=", c) << ';' << std::endl;
+    // F.write(std::cerr << "d:=", d) << ';' << std::endl;
+    // F.write(std::cerr << "e:=", e) << ';' << std::endl;
+    // F.write(std::cerr << "e_:=", e_) << ';' << std::endl;
+    // F.write(std::cerr << "a_:=", a_) << ';' << std::endl;
+    // F.write(std::cerr << "b_:=", b_) << ';' << std::endl;
     TEST_EQUALITY(e,e_); // a^2 - b^2 = (a-b)(a+b) ;)
 
     // Four operations


### PR DESCRIPTION
`maxCardinality` in Givaro's fields and rings ensures that the ring will be able to compute correctly all of its elementary operations. For Modular and ModularBalanced classes, this means checking that an axpy can be stored unreduced in the `Compute_t`.
This is (p-1)^2+(p-1) < 2^N on any unsigned representation of N bit integers for Modular or ((p-1)/2)^2+(p-1)/2<2^N on ModularBalanced
Now in FFLAS, the requirement is that a 1x1 fgemm can be run without reductions, which is that the integer type can store the sum of 2 products (or a 2x2 determinant).
This becomes 2(p-1)^2<2^N or 2((p-1)/2)^2<2^N.

This PR implements this by introducing a new method `maxFFLASCardinality` and fixing sub-optimal values in the current `maxCardinality` 