### PR TITLE
Write floating point field elements as signed int

### DIFF
--- a/src/kernel/ring/modular-general.inl
+++ b/src/kernel/ring/modular-general.inl
@@ -29,11 +29,21 @@ template<typename T, typename Enable = void>
 struct make_unsigned_int {
     typedef typename std::make_unsigned<T>::type type;
 };
+template<typename T, typename Enable = void>
+struct make_signed_int {
+    typedef typename std::make_signed<T>::type type;
+};
 
 template<typename T>
 struct make_unsigned_int<T,
 typename std::enable_if<std::is_floating_point<T>::value>::type> {
     typedef typename IntType<std::is_same<T,float>::value>::utype type;
+};
+
+template<typename T>
+struct make_signed_int<T,
+typename std::enable_if<std::is_floating_point<T>::value>::type> {
+    typedef typename IntType<std::is_same<T,float>::value>::type type;
 };
 
 template<typename> struct is_ruint : std::false_type {};

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -353,7 +353,7 @@ namespace Givaro {
         __GIVARO_CONDITIONAL_TEMPLATE(E = Element, IS_FLOAT(E))
         inline std::ostream& write (std::ostream& s, const E& a) const
         {
-            return s << Caster<typename make_signed_int<Storage_t>>(a);
+            return s << Caster<typename make_signed_int<Storage_t>::type>(a);
         }
 
         std::ostream& write (std::ostream& s) const

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -353,7 +353,7 @@ namespace Givaro {
         __GIVARO_CONDITIONAL_TEMPLATE(E = Element, IS_FLOAT(E))
         inline std::ostream& write (std::ostream& s, const E& a) const
         {
-            return s << Caster<Residu_t>(a);
+            return s << Caster<typename make_signed_int<Storage_t>>(a);
         }
 
         std::ostream& write (std::ostream& s) const


### PR DESCRIPTION
Until now, the `write` method of `Modular<float>` and `Modular<double>` made a cast to `Residu_t` which was a unsigned int (32 or 64 bits).
In fflas, these elements may be not reduced modulo p, and therefore can be negative. The code would then add 2^32 causing a bug in the value being printed.

This PR, changes the cast to a signed int type.