### PR TITLE
fabi-version=6 only if gcc version < 5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ FPMATH_FLAGS
 # __m256 are the same types and therefore we cannot have overloads for both
 # types without linking error. It is fixed in ABI version 4.
 # FIXME: Why do we set ABI version to 6 ?
-AS_IF([test "x$CCNAM" = "xgccl5"],[REQUIRED_FLAGS+=" -fabi-version=6"])
+AS_CASE([$CCNAM], [gcc4*], [REQUIRED_FLAGS+=" -fabi-version=6"])
 
 AS_ECHO([---------------------------------------])
 # Machine characteristics

--- a/configure.ac
+++ b/configure.ac
@@ -73,8 +73,8 @@ FPMATH_FLAGS
 # With GCC 4.x, the default ABI version is 2. With this version, __m128 and
 # __m256 are the same types and therefore we cannot have overloads for both
 # types without linking error. It is fixed in ABI version 4.
-# FIXME: Why do we set ABI version to 6 ? Why is it not done for GCC 4.9.x ?
-AS_IF([test "x$CCNAM" = "xgcc48"],[REQUIRED_FLAGS+=" -fabi-version=6"])
+# FIXME: Why do we set ABI version to 6 ?
+AS_IF([test "x$CCNAM" = "xgccl5"],[REQUIRED_FLAGS+=" -fabi-version=6"])
 
 AS_ECHO([---------------------------------------])
 # Machine characteristics
@@ -88,7 +88,7 @@ AC_CHECK_SIZEOF(long long)
 AC_CHECK_SIZEOF(__int64_t)
 
 # Looking for int128
-AC_CHECK_TYPE([__int128_t], [AC_TRY_COMPILE([#include <type_traits>], [std::make_unsigned<__int128_t>::type y;],[AC_DEFINE(HAVE_INT128, 1, [Define that compiler allows int128_t types])])])		   
+AC_CHECK_TYPE([__int128_t], [AC_TRY_COMPILE([#include <type_traits>], [std::make_unsigned<__int128_t>::type y;],[AC_DEFINE(HAVE_INT128, 1, [Define that compiler allows int128_t types])])])
 
 
 # check endianness of the architecture

--- a/macros/debug.m4
+++ b/macros/debug.m4
@@ -131,6 +131,17 @@ AC_DEFUN([AC_COMPILER_NAME], [
             [ CCNAM=gcc48 ])
         ])
 
+    dnl GCC <= 5 ?
+    AS_IF([ test -z "${CCNAM}"], [
+        AC_TRY_RUN( [
+            #ifdef __GNUC__
+                int main() { return !(__GNUC__ < 5))) ; }
+            #else
+               not gcc neither.
+            #endif],
+            [ CCNAM=gccl5 ])
+        ])
+
     dnl other ?
     AS_IF([ test -z "${CCNAM}"],
             [

--- a/macros/debug.m4
+++ b/macros/debug.m4
@@ -98,15 +98,26 @@ AC_DEFUN([AC_COMPILER_NAME], [
             [ CCNAM=clang38 ])
         ])
 
-    dnl GCC >= 4.9.3 ?
+    dnl GCC >= 5 ?
     AS_IF([ test -z "${CCNAM}"], [
         AC_TRY_RUN( [
             #ifdef __GNUC__
-                int main() { return !(__GNUC__ >= 5 || (__GNUC__ == 4  && (__GNUC_MINOR__ > 9 || (__GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ >= 3)))) ; }
+                int main() { return !(__GNUC__ >= 5 ) ; }
             #else
                 not gcc neither.
             #endif],
             [ CCNAM=gcc ])
+        ])
+
+    dnl 4.3 <= GCC < 5 ?
+    AS_IF([ test -z "${CCNAM}"], [
+        AC_TRY_RUN( [
+            #ifdef __GNUC__
+                int main() { return !(__GNUC__ == 4 && __GNUC_MINOR__ >= 3) ; }
+            #else
+               not gcc neither.
+            #endif],
+            [ CCNAM=gcc4 ])
         ])
 
     dnl GCC == 4.9.2 ?
@@ -118,28 +129,6 @@ AC_DEFUN([AC_COMPILER_NAME], [
                not gcc neither.
             #endif],
             [ CCNAM=gcc492 ])
-        ])
-
-    dnl GCC >= 4.8 and < 4.9.2 ?
-    AS_IF([ test -z "${CCNAM}"], [
-        AC_TRY_RUN( [
-            #ifdef __GNUC__
-                int main() { return !(__GNUC__ == 4  && (__GNUC_MINOR__ == 8 || (__GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ < 2))) ; }
-            #else
-               not gcc neither.
-            #endif],
-            [ CCNAM=gcc48 ])
-        ])
-
-    dnl GCC <= 5 ?
-    AS_IF([ test -z "${CCNAM}"], [
-        AC_TRY_RUN( [
-            #ifdef __GNUC__
-                int main() { return !(__GNUC__ < 5))) ; }
-            #else
-               not gcc neither.
-            #endif],
-            [ CCNAM=gccl5 ])
         ])
 
     dnl other ?


### PR DESCRIPTION
Uniformize fabi-version=6 only if gcc version < 5 in givaro/fflas/linbox.
Required as a kludge before cleanup the full autotools mechanisms, as otherwise there are incompatibilities between givaro/fflas/linbox.
See similar PR in fflas/linbox: [fflas PR305](https://github.com/linbox-team/fflas-ffpack/pull/305) and [linbox PR248](https://github.com/linbox-team/linbox/pull/248).