### PR TITLE
remove 1st and last lines in givaro.pc.in

### DIFF
--- a/givaro.pc.in
+++ b/givaro.pc.in
@@ -1,4 +1,3 @@
-/------------------ givaro.pc ------------------------
 prefix=@prefix@
 exec_prefix=@prefix@
 libdir=@prefix@/lib
@@ -11,4 +10,3 @@ Version: @VERSION@
 Requires:
 Libs: -L@libdir@ -lgivaro @GMP_LIBS@
 Cflags: -I@includedir@ @REQUIRED_FLAGS@
-\-------------------------------------------------------


### PR DESCRIPTION
these two extra lines are probably a historical artefact, totally unneeded, and causing errors if a non-bash is used as the "main" shell.