### PR TITLE
Add const version of Integer::operator=()

### DIFF
--- a/src/kernel/gmp++/gmp++_int.h
+++ b/src/kernel/gmp++/gmp++_int.h
@@ -234,6 +234,7 @@ namespace Givaro {
          */
         ///@{
         giv_all_inlined Integer& operator = (const Integer& n);
+        giv_all_inlined Integer& operator = (const Integer& n) const;
         giv_all_inlined Integer& logcpy(const Integer& n);
         giv_all_inlined Integer& copy(const Integer& n);
         ///@}

--- a/src/kernel/gmp++/gmp++_int_cstor.C
+++ b/src/kernel/gmp++/gmp++_int_cstor.C
@@ -105,6 +105,11 @@ namespace Givaro {
         return logcpy(n) ;
     }
 
+    Integer& Integer::operator = (const Integer &n) const
+    {
+        return const_cast<Integer*>(this)->logcpy(n) ;
+    }
+
 
     Integer& Integer::copy(const Integer &n)
     {


### PR DESCRIPTION
When building `sage` with latest releases of `linbox` and `givaro` I get following error:

```
[sagelib-9.1] In file included from build/cythonized/sage/matrix/matrix_modn_sparse.cpp:4089:
[sagelib-9.1] In file included from /usr/local/include/linbox/solutions/charpoly.h:34:
[sagelib-9.1] In file included from /usr/local/include/linbox/algorithms/bbcharpoly.h:46:
[sagelib-9.1] In file included from /usr/local/include/linbox/solutions/det.h:608:
[sagelib-9.1] /usr/local/include/linbox/algorithms/det-rational.h:95:39: error: no viable overloaded '='
[sagelib-9.1]                 void setDiv (const Integer& d) {div = d;}
[sagelib-9.1]                                                 ~~~ ^ ~
[sagelib-9.1] /usr/local/include/gmp++/gmp++_int.h:236:34: note: candidate function not viable: 'this' argument has type 'const LinBox::Integer' (aka 'const Givaro::Integer'), but method is not marked const
[sagelib-9.1]         giv_all_inlined Integer& operator = (const Integer& n);
[sagelib-9.1]                                  ^
```

This PR fixes the error, but I'm not sure it is a correct solution.