### PR TITLE
Add more type_string static method to Modular, ModularBalanced and ModularExtended classes

### DIFF
--- a/src/kernel/gmp++/gmp++_int.h
+++ b/src/kernel/gmp++/gmp++_int.h
@@ -217,6 +217,11 @@ namespace Givaro {
         giv_all_inlined ~Integer();
         ///@}
 
+        // -- type_string
+        static const std::string type_string () {
+            return "Integer";
+        }
+
         //------------------------------------- predefined null and one
         //! zero (0)
         static const Integer zero ;

--- a/src/kernel/recint/rrint.h
+++ b/src/kernel/recint/rrint.h
@@ -42,6 +42,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 #include "recdefine.h"
 #include "ruruint.h"
+#include "givaro/givtypestring.h"
 #include "rumanip.h" // ms_limb
 
 // --------------------------------------------------------------
@@ -62,6 +63,11 @@ namespace RecInt
         { if (rl < 0) { Value.Low = -Value.Low; Value = -Value; } }
         rint(const ruint<K>& r) : Value(r) {}
         template <typename T> rint(const T& b) : Value(b) {}
+
+        // type_string
+        static const std::string type_string () {
+            return "RecInt::rint<" + std::to_string(K)+ ">";
+        }
 
         // Cast
         template <typename T> operator T() const { return static_cast<T>(Value); }

--- a/src/kernel/recint/ruint.h
+++ b/src/kernel/recint/ruint.h
@@ -42,6 +42,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 #define RUINT_H
 
 #include "givaro-config.h"
+#include "givaro/givtypestring.h"
 
 /* Class definition */
 #include "ruruint.h"

--- a/src/kernel/recint/ruruint.h
+++ b/src/kernel/recint/ruruint.h
@@ -67,6 +67,11 @@ namespace RecInt
 
         ruint(const char* s);
 
+        // type_string
+        static const std::string type_string () {
+            return "RecInt::ruint<" + std::to_string(K)+ ">";
+        }
+
         // Cast
         // Note: Templated operators and specialization make compilers clang + icpc
         // completely bug (they do not use the template operator somehow)
@@ -133,6 +138,11 @@ namespace RecInt
         { *this = b.operator ruint<__RECINT_LIMB_SIZE>(); } // Fix for Givaro::Integer
         ruint(const char* s);
 
+        // type_string
+        static const std::string type_string () {
+            return "RecInt::ruint<" + std::to_string(__RECINT_LIMB_SIZE)+ ">";
+        }
+
         // Cast
         // Brutal too, but icc is kind of peaky - AB 2015/02/11
         operator bool() const { return bool(Value); }
@@ -196,6 +206,11 @@ namespace RecInt
         template <typename T, __RECINT_IS_NOT_FUNDAMENTAL(T, int) = 0> ruint(const T& b)
         { *this = b.operator ruint<__RECINT_LIMB_SIZE+1>(); } // Fix for Givaro::Integer
         ruint(const char* s);
+
+        // type_string
+        static const std::string type_string () {
+            return "RecInt::ruint<" + std::to_string(__RECINT_LIMB_SIZE+1)+ ">";
+        }
 
         // Cast
         operator float() const { return (float)(Value); }

--- a/src/kernel/ring/modular-balanced-double.h
+++ b/src/kernel/ring/modular-balanced-double.h
@@ -16,6 +16,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-general.h"
 
@@ -149,6 +150,11 @@ namespace Givaro
         // -- maxpyin: r <- r - a * x
         Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
         Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+        // -- type_string
+        static const std::string type_string () {
+            return "ModularBalanced<" + TypeString<Element>::get() +  ">";
+        }
 
         // ----- Random generators
         typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-balanced-float.h
+++ b/src/kernel/ring/modular-balanced-float.h
@@ -16,6 +16,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-general.h"
 
@@ -150,6 +151,11 @@ namespace Givaro
         // -- maxpyin: r <- r - a * x
         Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
         Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+        // -- type_string
+        static const std::string type_string () {
+            return "ModularBalanced<" + TypeString<Element>::get() +  ">";
+        }
 
         // ----- Random generators
         typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-balanced-int32.h
+++ b/src/kernel/ring/modular-balanced-int32.h
@@ -17,6 +17,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 
 namespace Givaro
@@ -145,6 +146,11 @@ namespace Givaro
         // -- maxpyin: r <- r - a * x
         Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
         Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+        // -- type_string
+        static const std::string type_string () {
+            return "ModularBalanced<" + TypeString<Element>::get() +  ">";
+        }
 
         // ----- Random generators
         typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-balanced-int64.h
+++ b/src/kernel/ring/modular-balanced-int64.h
@@ -17,6 +17,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 
 namespace Givaro
@@ -142,6 +143,11 @@ namespace Givaro
         // -- maxpyin: r <- r - a * x
         Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
         Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+        // -- type_string
+        static const std::string type_string () {
+            return "ModularBalanced<" + TypeString<Element>::get() +  ">";
+        }
 
         // ----- Random generators
         typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-extended.h
+++ b/src/kernel/ring/modular-extended.h
@@ -15,6 +15,7 @@
 #include "givaro/givconfig.h"
 
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-general.h"
 
@@ -241,6 +242,11 @@ namespace Givaro{
         }
         Element& maxpyin(Element& r, const Element& a, const Element& x) const {
             return maxpy(r, a, x, r);
+        }
+
+        // -- type_string
+        static const std::string type_string () {
+            return "ModularExtended<" + TypeString<Element>::get() +  ">";
         }
 
         // ----- Random generators

--- a/src/kernel/ring/modular-floating.h
+++ b/src/kernel/ring/modular-floating.h
@@ -22,6 +22,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-general.h"
 #include "givaro/modular-implem.h"
@@ -113,6 +114,13 @@ namespace Givaro
         // -- maxpyin: r <- r - a * x
         Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
         Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+        // -- type_string
+        static const std::string type_string () {
+            return "Modular<" + TypeString<Storage_t>::get()
+                    + (sizeof(Storage_t) == sizeof(Compute_t) ?
+                        "" : ", " + TypeString<Compute_t>::get() ) +  ">";
+        }
 
         // ----- Random generators
         typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-implem.h
+++ b/src/kernel/ring/modular-implem.h
@@ -20,6 +20,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-general.h"
 
@@ -229,42 +230,10 @@ namespace Givaro {
 
         // --------
         // -- type_string
-
-        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SINT(S))
-        std::string type_string() const {
-            std::size_t k = sizeof(S);
-            return "Modular<int" + std::to_string(8*k) + "_t>";
-        }
-
-        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_UINT(S))
-        std::string type_string() const {
-            std::size_t k = sizeof(S);
-            return "Modular<uint" + std::to_string(8*k) + "_t>";
-        }
-
-        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, float))
-        std::string type_string() const {
-            return "Modular<float>";
-        }
-
-        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, double))
-        std::string type_string() const {
-            return "Modular<double>";
-        }
-
-        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, IS_SAME(S, Integer))
-        std::string type_string() const {
-            return "Modular<Integer>";
-        }
-
-        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, is_ruint<S>::value)
-        std::string type_string() const {
-            return "Modular<RecInt::ruint<" + std::to_string(RecInt_K<S>::value) + ">>";
-        }
-
-        __GIVARO_CONDITIONAL_TEMPLATE(S = Storage_t, !IS_INT(S) && !IS_FLOAT(S) && !IS_SAME(S, Integer) && !is_ruint<S>::value)
-        std::string type_string() const {
-            return "<Modular<IntType>>";
+        static const std::string type_string () {
+            return "Modular_implem<" + TypeString<Storage_t>::get()
+                             +  ", " + TypeString<Compute_t>::get()
+                             +  ", " + TypeString<Residu_t>::get() + ">";
         }
 
         // --------

--- a/src/kernel/ring/modular-integer.h
+++ b/src/kernel/ring/modular-integer.h
@@ -16,6 +16,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/modular-general.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-implem.h"
@@ -89,6 +90,11 @@ namespace Givaro
         // -- maxpyin: r <- r - a * x
         Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
         Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+        // -- type_string
+        static const std::string type_string () {
+            return "Modular<" + TypeString<Integer>::get() +  ">";
+        }
 
         // ----- Random generators
         typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-integral.h
+++ b/src/kernel/ring/modular-integral.h
@@ -19,6 +19,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-general.h"
 #include "givaro/modular-implem.h"
@@ -131,6 +132,13 @@ namespace Givaro {
               Element& axmy (Element&, const Element&, const Element&, const Element&) const;
               Element& maxpyin (Element&, const Element&, const Element&) const;
               Element& axmyin (Element&, const Element&, const Element&) const;
+
+              // -- type_string
+              static const std::string type_string () {
+                  return "Modular<" + TypeString<Storage_t>::get()
+                        + (sizeof(Storage_t) == sizeof(Compute_t) ?
+                            "" : ", " + TypeString<Compute_t>::get() ) +  ">";
+              }
 
               // ----- Random generators
               typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-inttype.h
+++ b/src/kernel/ring/modular-inttype.h
@@ -21,6 +21,7 @@
 #include "givaro/givinteger.h"
 #include "givaro/givcaster.h"
 #include "givaro/givranditer.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-implem.h"
 #include "givaro/modular-general.h"
@@ -99,6 +100,14 @@ namespace Givaro
         // -- maxpyin: r <- r - a * x
         Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
         Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+        // --------
+        // -- type_string
+        static const std::string type_string () {
+            return "Modular<" + TypeString<Storage_t>::get()
+                    + (std::is_same<Storage_t, Compute_t>::value ?
++                        "" : ", " + TypeString<Compute_t>::get() ) +  ">";
+        }
 
         // ----- Random generators
         typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/ring/modular-ruint.h
+++ b/src/kernel/ring/modular-ruint.h
@@ -13,6 +13,7 @@
 
 #include "recint/ruint.h"
 #include "givaro/givinteger.h"
+#include "givaro/givtypestring.h"
 #include "givaro/ring-interface.h"
 #include "givaro/modular-general.h"
 #include "givaro/givranditer.h"
@@ -101,6 +102,13 @@ namespace Givaro
               // -- maxpyin: r <- r - a * x
               Element& maxpy  (Element& r, const Element& a, const Element& x, const Element& y) const;
               Element& maxpyin(Element& r, const Element& a, const Element& x) const;
+
+              // -- type_string
+              static const std::string type_string () {
+              return "Modular<" + TypeString<Storage_t>::get()
+                        + (sizeof(Storage_t) == sizeof(Compute_t) ?
+                            "" : ", " + TypeString<Compute_t>::get() ) +  ">";
+              }
 
               // ----- Random generators
               typedef ModularRandIter<Self_t> RandIter;

--- a/src/kernel/system/Makefile.am
+++ b/src/kernel/system/Makefile.am
@@ -24,6 +24,7 @@ pkginclude_HEADERS= \
 	givtimer.h	    \
 	givomptimer.h	\
 	givranditer.h\
+	givtypestring.h \
 	udl.h
 
 noinst_LTLIBRARIES=libgivsystem.la

--- a/src/kernel/system/givtypestring.h
+++ b/src/kernel/system/givtypestring.h
@@ -1,0 +1,75 @@
+// ==========================================================================
+// Copyright(c)'1994-2020 by The Givaro group
+// This file is part of Givaro.
+// Givaro is governed by the CeCILL-B license under French law
+// and abiding by the rules of distribution of free software.
+// see the COPYRIGHT file for more details.
+// Authors: C. Bouvier
+// ==========================================================================
+
+#ifndef __GIVARO_typestring_H
+#define __GIVARO_typestring_H
+
+#include <string>
+#include <type_traits>
+
+namespace Givaro {
+
+    template <typename T>
+    class HasTypeString
+    {
+    private:
+        typedef char YesType[1];
+        typedef char NoType[2];
+
+        template <typename C> static YesType& test (decltype(&C::type_string));
+        template <typename C> static NoType& test (...);
+
+    public:
+        static constexpr bool value = sizeof(test<T>(0)) == sizeof(YesType);
+    };
+
+
+    template <class T>
+    struct TypeString
+    {
+        template <bool B, class R = void>
+        using enable_if_t = typename std::enable_if<B, R>::type;
+
+        /* base type, integral: char, int8_t, uint32_t, ... */
+        template <class C = T, enable_if_t<std::is_integral<C>::value>* = nullptr>
+        static std::string get () {
+            std::string s = std::string(std::is_signed<C>::value ? "int" : "uint");
+            return s + std::to_string(8*sizeof(C)) + "_t";
+        }
+
+        /* base type: bool */
+        template <class C = T, enable_if_t<std::is_same<C, bool>::value>* = nullptr>
+        static std::string get () {
+            return "bool";
+        }
+
+        /* base type: float */
+        template <class C = T, enable_if_t<std::is_same<C,float>::value>* = nullptr>
+        static std::string get () {
+            return "float";
+        }
+
+        /* base type: double */
+        template <class C = T, enable_if_t<std::is_same<C,double>::value>* = nullptr>
+        static std::string get () {
+            return "double";
+        }
+
+        /* class with type_string static method */
+        template <class U = T, enable_if_t<HasTypeString<U>::value>* = nullptr>
+        static std::string get () {
+            return T::type_string();
+        }
+    };
+
+}
+
+#endif /* __GIVARO_typestring_H */
+/* -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+// vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s


### PR DESCRIPTION
This PR add a static method type_string to lots of Modular, ModularBalanced and ModuarExtended classes. Before, only Modular_implem had a type_string static method.

Example of usage:
```cpp
#include "givaro/modular.h"
#include "givaro/modular-extended.h"
#include "givaro/modular-balanced.h"

int
main (int argc, char *argv[])
{
  std::cout << Givaro::Modular<int32_t>::type_string() << std::endl;
  std::cout << Givaro::Modular<int32_t, int64_t>::type_string() << std::endl;
  std::cout << Givaro::Modular<uint64_t>::type_string() << std::endl;
  std::cout << Givaro::Modular<uint64_t, __uint128_t>::type_string() << std::endl;
  std::cout << Givaro::Modular<Givaro::Integer>::type_string() << std::endl;
  std::cout << Givaro::Modular<float>::type_string() << std::endl;
  std::cout << Givaro::Modular<float, double>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::ruint<6>>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::ruint<7>>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::ruint<7>,RecInt::ruint<9>>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::ruint<10>>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::rint<6>>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::rint<7>>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::rint<7>,RecInt::rint<9>>::type_string() << std::endl;
  std::cout << Givaro::Modular<RecInt::rint<10>>::type_string() << std::endl;

  std::cout << Givaro::ModularExtended<float>::type_string() << std::endl;
  std::cout << Givaro::ModularExtended<double>::type_string() << std::endl;

  std::cout << Givaro::ModularBalanced<float>::type_string() << std::endl;
  std::cout << Givaro::ModularBalanced<double>::type_string() << std::endl;
  std::cout << Givaro::ModularBalanced<int32_t>::type_string() << std::endl;
  std::cout << Givaro::ModularBalanced<int64_t>::type_string() << std::endl;

  return 0;
}
```

which outputs

```
Modular<int32_t>
Modular<int32_t, uint64_t>
Modular<uint64_t>
Modular<uint64_t, uint128_t>
Modular<Integer>
Modular<float>
Modular<float, double>
Modular<RecInt::ruint<6>>
Modular<RecInt::ruint<7>>
Modular<RecInt::ruint<7>, RecInt::ruint<9>>
Modular<RecInt::ruint<10>>
Modular<RecInt::rint<6>>
Modular<RecInt::rint<7>>
Modular<RecInt::rint<7>, RecInt::rint<9>>
Modular<RecInt::rint<10>>
ModularExtended<float>
ModularExtended<double>
ModularBalanced<float>
ModularBalanced<double>
ModularBalanced<int32_t>
ModularBalanced<int64_t>
```