### PR TITLE
Remove support for old gcc 4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,12 +71,6 @@ ARCH_FLAGS
 # Append -mfpmath=sse to OPTIM_FLAGS on i386 and i686 architecture with SSE
 FPMATH_FLAGS
 
-# With GCC 4.x, the default ABI version is 2. With this version, __m128 and
-# __m256 are the same types and therefore we cannot have overloads for both
-# types without linking error. It is fixed in ABI version 4.
-# FIXME: Why do we set ABI version to 6 ?
-AS_CASE([$CCNAM], [gcc4*], [REQUIRED_FLAGS+=" -fabi-version=6"])
-
 AS_ECHO([---------------------------------------])
 # Machine characteristics
 

--- a/macros/debug.m4
+++ b/macros/debug.m4
@@ -109,28 +109,6 @@ AC_DEFUN([AC_COMPILER_NAME], [
             [ CCNAM=gcc ])
         ])
 
-    dnl 4.3 <= GCC < 5 ?
-    AS_IF([ test -z "${CCNAM}"], [
-        AC_TRY_RUN( [
-            #ifdef __GNUC__
-                int main() { return !(__GNUC__ == 4 && __GNUC_MINOR__ >= 3) ; }
-            #else
-               not gcc neither.
-            #endif],
-            [ CCNAM=gcc4 ])
-        ])
-
-    dnl GCC == 4.9.2 ?
-    AS_IF([ test -z "${CCNAM}"], [
-        AC_TRY_RUN( [
-            #ifdef __GNUC__
-                int main() { return !(__GNUC__ == 4  && __GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ == 2 ) ; }
-            #else
-               not gcc neither.
-            #endif],
-            [ CCNAM=gcc492 ])
-        ])
-
     dnl other ?
     AS_IF([ test -z "${CCNAM}"],
             [


### PR DESCRIPTION
Remove support for gcc < 5.
Will propose a PR with the same changes for fflas and linbox