### PR TITLE
givaro-makefile updates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,8 @@ benchmarks/perfpublisher:
 tests/perfpublisher:
 	(cd tests; ${MAKE} perfpublisher)
 
-bin_SCRIPTS=givaro-config givaro-makefile
+bin_SCRIPTS=givaro-config
+pkgdata_DATA = givaro-makefile
 
 EXTRA_DIST=COPYRIGHT Licence_CeCILL-B_V1-en.txt Licence_CeCILL-B_V1-fr.txt \
 	   givaro.doxy \

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:<path to your givaro install>/lib/pkgconfig
 
 An alternative option is to just add the following line to your Makefile. Then a simple call will compile your C and C++ files.
 ```
-include ##GIVAROROOT##/bin/givaro-makefile
+include ##GIVAROROOT##/share/givaro/givaro-makefile
 ```
 
 

--- a/givaro-makefile.in
+++ b/givaro-makefile.in
@@ -1,4 +1,3 @@
-#! /bin/sh
 # Copyright(c)'2019 by The Givaro group
 # This file is part of Givaro.
 # Givaro is governed by the CeCILL-B license under French law


### PR DESCRIPTION
According to `README.md`, `givaro-makefile` is intended to be used as a Makefile snippet.  However, currently, it's installed as a script in `${bindir}`, complete with `#!/bin/sh` shebang.

Instead, we install it to `${pkgdatadir}` and drop the shebang.
