### PR TITLE
fix system header include syntax for local header

### DIFF
--- a/src/kernel/field/StaticElement.h
+++ b/src/kernel/field/StaticElement.h
@@ -20,7 +20,7 @@
 #define __GIVARO_static_element_H
 
 #include <iostream>
-#include <gmp++/gmp++.h>
+#include "gmp++/gmp++.h"
 
 namespace Givaro {
 


### PR DESCRIPTION
If /usr/include/gmp++/gmp++.h exists when givaro is built, that will
be used in preference to the (possibly modified) copy in
./src/kernel/gmp ++/.

Patch by Lifeng Sun; has been applied to the Debian package since
2012.  See https://bugs.debian.org/681589.