### PR TITLE
solves issue #169

### DIFF
--- a/src/kernel/integer/random-integer.h
+++ b/src/kernel/integer/random-integer.h
@@ -185,7 +185,9 @@ namespace Givaro
          * 1/ Constructor with 2 args, D and seed ...
          * 2/ ... then object.setBits(bits).
          */
-        RandomIntegerIterator(const Integer_Domain&, uint64_t, size_t);
+        RandomIntegerIterator(const Integer_Domain&, uint64_t, size_t); // DEPRECATED Constructor. Instead, call constructor with 2 args then object.setBits(bits)
+
+
     };
 
 }

--- a/src/kernel/integer/random-integer.h
+++ b/src/kernel/integer/random-integer.h
@@ -31,6 +31,8 @@ namespace Givaro
      * @tparam _Exact_Size if \c true, then random integers have
      * exactly the number of required bits, if \c false, they have
      * less than the required number of bits
+     * WARNING, the seed is *** global ***
+     * WARNING: i.e. sets the seed for all Givaro Integer 
      */
     template<bool _Unsigned=true, bool _Exact_Size=false>
     class RandomIntegerIterator {
@@ -56,15 +58,21 @@ namespace Givaro
 
     public:
         /*! Constructor.
-         * @param bits size of integers (in bits)
          * @param seed if \c 0 a seed will be generated, otherwise, the
-         * provided seed will be use.
+         * provided seed will be used, *** globally ***
+         * Default bit size (30) can be changed with method 'setBits'
          */
         RandomIntegerIterator(const Integer_Domain& D, uint64_t seed = 0) :
             _bits(30u), _integer(), _ring(D)
         {
             initialize(seed,_bits);
         }
+
+        /*! Constructor.
+         * @param seed if \c 0 a seed will be generated, otherwise, the
+         * provided seed will be used, *** globally ***
+         * @param samplesize is number ofpossible random values
+         */
         RandomIntegerIterator(const Integer_Domain& D, uint64_t seed, const Integer& samplesize) : _bits(samplesize.bitsize()), _integer(), _ring(D)
         {
             initialize(seed,_bits);
@@ -131,14 +139,14 @@ namespace Givaro
             return this->operator()();
         }
 
-        /** @brief Sets the seed.
+        /** @brief Sets the seed *** globally ***
+         *  WARNING: i.e. sets the seed for all Givaro Integer 
          *  Set the random seed to be \p ul.
          *  @param ul the new seed.
          */
-        void setSeed(uint64_t ul)
+        void static setSeed(uint64_t ul)
         {
             Givaro::Integer::seeding(ul);
-            this->operator++(); // next random value must depend on new seed
         }
 
         void setBits (size_t  bits)

--- a/src/kernel/integer/random-integer.h
+++ b/src/kernel/integer/random-integer.h
@@ -179,6 +179,13 @@ namespace Givaro
         Integer_Type			_integer;	//!< the generated integer.
         const Integer_Domain&	_ring;
 
+    private:
+        /*! DEPRECATED Constructor.
+         * This behavior can be now reproduced by calling:
+         * 1/ Constructor with 2 args, D and seed ...
+         * 2/ ... then object.setBits(bits).
+         */
+        RandomIntegerIterator(const Integer_Domain&, uint64_t, size_t);
     };
 
 }

--- a/src/kernel/integer/random-integer.h
+++ b/src/kernel/integer/random-integer.h
@@ -45,8 +45,8 @@ namespace Givaro
     private:
         void initialize(uint64_t seed, const size_t bits)
         {
-            if (! bits) _bits = 30;
-            GIVARO_ASSERT( _bits>0, "[RandomIntegerIterator] bad bit size");
+            if (! bits) _bits = 30u;
+            GIVARO_ASSERT( _bits>0u, "[RandomIntegerIterator] bad bit size");
             int64_t s=seed;
             while (!s)
                 s = static_cast<uint64_t>(BaseTimer::seed());
@@ -60,8 +60,8 @@ namespace Givaro
          * @param seed if \c 0 a seed will be generated, otherwise, the
          * provided seed will be use.
          */
-        RandomIntegerIterator(const Integer_Domain& D, uint64_t seed = 0, size_t bits = 30) :
-            _bits(bits), _integer(), _ring(D)
+        RandomIntegerIterator(const Integer_Domain& D, uint64_t seed = 0) :
+            _bits(30u), _integer(), _ring(D)
         {
             initialize(seed,_bits);
         }

--- a/src/kernel/integer/random-integer.h
+++ b/src/kernel/integer/random-integer.h
@@ -135,7 +135,7 @@ namespace Givaro
          *  Set the random seed to be \p ul.
          *  @param ul the new seed.
          */
-        void static setSeed(uint64_t ul)
+        void setSeed(uint64_t ul)
         {
             Givaro::Integer::seeding(ul);
             this->operator++(); // next random value must depend on new seed

--- a/src/kernel/integer/random-integer.h
+++ b/src/kernel/integer/random-integer.h
@@ -138,11 +138,13 @@ namespace Givaro
         void static setSeed(uint64_t ul)
         {
             Givaro::Integer::seeding(ul);
+            this->operator++(); // next random value must depend on new seed
         }
 
         void setBits (size_t  bits)
         {
             _bits = bits;
+            this->operator++(); // next random value must depend on new bitsize
         }
 
         size_t getBits () const


### PR DESCRIPTION
By removing the constructor with a bitsize. 
To setup a sample with a maximal bitsize , use the existing method "setBits(size_t)".