### PR TITLE
Resof

### DIFF
--- a/src/kernel/system/givranditer.h
+++ b/src/kernel/system/givranditer.h
@@ -301,9 +301,7 @@ namespace Givaro {
         Element& operator() (Element& a) const
         {
                 // If no size given and cardinality is 0
-            return ring().init(a, _size?
-                               _givrand() % static_cast<std::result_of<_givrand()>>(_size)
-                               :_givrand());
+            return ring().init(a, _size? _givrand() % static_cast<GivRandom::random_t>(_size) :_givrand());
         }
         Element& random (Element& a) const
         {

--- a/src/kernel/system/givranditer.h
+++ b/src/kernel/system/givranditer.h
@@ -301,7 +301,9 @@ namespace Givaro {
         Element& operator() (Element& a) const
         {
                 // If no size given and cardinality is 0
-            return ring().init(a, _size?_givrand() % _size:_givrand());
+            return ring().init(a, _size?
+                               _givrand() % static_cast<std::result_of<_givrand()>>(_size)
+                               :_givrand());
         }
         Element& random (Element& a) const
         {

--- a/src/kernel/system/givrandom.h
+++ b/src/kernel/system/givrandom.h
@@ -37,6 +37,8 @@ namespace Givaro {
         mutable uint64_t _seed;
     public:
         typedef GivRandom random_generator;
+        typedef uint64_t random_t;
+        typedef uint64_t seed_t;
 
         GivRandom(const uint64_t s = 0)
         : _seed(s)
@@ -61,15 +63,11 @@ namespace Givaro {
             return _seed;
         }
 
-
         uint64_t max_rand() const
         {
             return _GIVRAN_MODULO_;
         }
 
-
-        // #if defined(__GIVARO_INT64)
-#if 1
         uint64_t operator() () const
         {
             return _seed = (uint64_t)(
@@ -77,15 +75,6 @@ namespace Givaro {
                                       * (int64_t)_seed
                                       % (int64_t)_GIVRAN_MODULO_ );
         }
-#else
-        uint64_t operator() () const
-        {
-            return _seed = (uint64_t)(
-                                      (uint64_t)_GIVRAN_MULTIPLYER_
-                                      * _seed
-                                      % (uint64_t)_GIVRAN_MODULO_ );
-        }
-#endif
 
         template<class XXX> XXX& operator() (XXX& x) const
         {


### PR DESCRIPTION
% does not exist for floating types.
need to cast toward return type of givrandom beforehand.