### PR TITLE
make modular balanced double print the size not in scientific notation

### DIFF
--- a/src/kernel/ring/modular-balanced-double.inl
+++ b/src/kernel/ring/modular-balanced-double.inl
@@ -231,7 +231,7 @@ namespace Givaro
     inline std::ostream&
     ModularBalanced<double>::write(std::ostream& os) const
     {
-        return os << "ModularBalanced<double> modulo " << static_cast<uint64_t>(_p); // TODO maybe write a cleaner convert some time
+        return os << "ModularBalanced<double> modulo " << static_cast<uint64_t>(_p); // _p in ModularBalanced<double> is always < 2**64
     }
 
     inline std::ostream&

--- a/src/kernel/ring/modular-balanced-double.inl
+++ b/src/kernel/ring/modular-balanced-double.inl
@@ -231,7 +231,7 @@ namespace Givaro
     inline std::ostream&
     ModularBalanced<double>::write(std::ostream& os) const
     {
-        return os << "ModularBalanced<double> mod " << _p;
+        return os << "ModularBalanced<double> modulo " << static_cast<uint64_t>(_p); // TODO maybe write a cleaner convert some time
     }
 
     inline std::ostream&

--- a/src/kernel/ring/modular-balanced-float.inl
+++ b/src/kernel/ring/modular-balanced-float.inl
@@ -246,7 +246,7 @@ namespace Givaro
     inline std::ostream&
     ModularBalanced<float>::write(std::ostream& os) const
     {
-        return os << "ModularBalanced<float> modulo " << _p;
+        return os << "ModularBalanced<float> modulo " << static_cast<uint32_t>(_p); // _p in ModularBalanced<double> is always < 2**32 
     }
 
     inline std::ostream&

--- a/src/kernel/ring/modular-balanced-float.inl
+++ b/src/kernel/ring/modular-balanced-float.inl
@@ -246,7 +246,7 @@ namespace Givaro
     inline std::ostream&
     ModularBalanced<float>::write(std::ostream& os) const
     {
-        return os << "ModularBalanced<float> mod " << _p;
+        return os << "ModularBalanced<float> modulo " << _p;
     }
 
     inline std::ostream&

--- a/src/kernel/ring/modular-balanced-int32.inl
+++ b/src/kernel/ring/modular-balanced-int32.inl
@@ -249,7 +249,7 @@ namespace Givaro
     inline std::ostream&
     ModularBalanced<int32_t>::write(std::ostream& os) const
     {
-        return os << "ModularBalanced<int32_t> mod " << _p;
+        return os << "ModularBalanced<int32_t> modulo " << _p;
     }
 
     inline std::ostream&

--- a/src/kernel/ring/modular-balanced-int64.inl
+++ b/src/kernel/ring/modular-balanced-int64.inl
@@ -233,7 +233,7 @@ namespace Givaro
     inline std::ostream&
     ModularBalanced<int64_t>::write(std::ostream& os) const
     {
-        return os << "ModularBalanced<int64_t> mod " << _p;
+        return os << "ModularBalanced<int64_t> modulo " << _p;
     }
 
     inline std::ostream&


### PR DESCRIPTION
...also make everyone print ”modulo” (instead of “mod” for the balanced int/float)  