### PR TITLE
test sizeof(long) instead of GMP limb size

### DIFF
--- a/src/kernel/gmp++/gmp++_int_add.C
+++ b/src/kernel/gmp++/gmp++_int_add.C
@@ -34,7 +34,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return res = n;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return addin(res,Integer(n));
 #else
         int32_t sgn = Givaro::sign(n);
@@ -47,7 +47,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return res = n;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return addin(res,Integer(n));
 #else
         mpz_add_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -66,7 +66,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = n2;
         if (isZero(n2)) return res = n1;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return add(res,n1,Integer(n2));
 #else
         int32_t sgn = Givaro::sign(n2);
@@ -79,7 +79,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = n2;
         if (isZero(n2)) return res = n1;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return add(res,n1,Integer(n2));
 #else
         mpz_add_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -101,7 +101,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(Integer(l));
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) += Integer(l);
 #else
         mpz_add_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -113,7 +113,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(Integer(l));
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) += Integer(l);
 #else
         int32_t sgn = Givaro::sign(l);
@@ -137,7 +137,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return Integer(l);
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) + Integer(l);
 #else
         Integer res;
@@ -150,7 +150,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return Integer(l);
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) + Integer(l);
 #else
         Integer res;

--- a/src/kernel/gmp++/gmp++_int_add.C
+++ b/src/kernel/gmp++/gmp++_int_add.C
@@ -34,7 +34,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return res = n;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return addin(res,Integer(n));
 #else
         int32_t sgn = Givaro::sign(n);
@@ -47,7 +47,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return res = n;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return addin(res,Integer(n));
 #else
         mpz_add_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -66,7 +66,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = n2;
         if (isZero(n2)) return res = n1;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return add(res,n1,Integer(n2));
 #else
         int32_t sgn = Givaro::sign(n2);
@@ -79,7 +79,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = n2;
         if (isZero(n2)) return res = n1;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return add(res,n1,Integer(n2));
 #else
         mpz_add_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -101,7 +101,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(Integer(l));
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) += Integer(l);
 #else
         mpz_add_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -113,7 +113,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(Integer(l));
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) += Integer(l);
 #else
         int32_t sgn = Givaro::sign(l);
@@ -137,7 +137,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return Integer(l);
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) + Integer(l);
 #else
         Integer res;
@@ -150,7 +150,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return Integer(l);
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) + Integer(l);
 #else
         Integer res;

--- a/src/kernel/gmp++/gmp++_int_compare.C
+++ b/src/kernel/gmp++/gmp++_int_compare.C
@@ -46,7 +46,7 @@ namespace Givaro {
 
     int32_t absCompare(const Integer &a, const uint64_t b)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return absCompare( a, Integer(b));
 #else
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), b);
@@ -55,7 +55,7 @@ namespace Givaro {
 
     int32_t absCompare(const Integer &a, const uint32_t b)
     {
-#if GMP_LIMB_BITS == 32
+#if __GIVARO_SIZEOF_LONG == 4
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), b);
 #else
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), (uint64_t)b);
@@ -64,7 +64,7 @@ namespace Givaro {
 
     int32_t absCompare(const Integer &a, const int64_t b)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return absCompare( a, Integer(b));
 #else
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), (uint64_t) std::abs(b));
@@ -73,7 +73,7 @@ namespace Givaro {
 
     int32_t absCompare(const Integer &a, const int32_t b)
     {
-#if GMP_LIMB_BITS == 32
+#if __GIVARO_SIZEOF_LONG == 4
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), std::abs(b));
 #else
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), (uint64_t) std::abs(b));
@@ -103,7 +103,7 @@ namespace Givaro {
 
     int32_t Integer::operator != (const uint32_t l) const
     {
-#if GMP_LIMB_BITS == 32
+#if __GIVARO_SIZEOF_LONG == 4
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, l) != 0;
 #else
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, (uint64_t) l) != 0;
@@ -112,7 +112,7 @@ namespace Givaro {
 
     int32_t Integer::operator != (const int64_t l) const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return this->operator != (Integer(l));
 #else
         return mpz_cmp_si((mpz_srcptr)&gmp_rep, l) != 0;
@@ -121,7 +121,7 @@ namespace Givaro {
 
     int32_t Integer::operator != (const uint64_t l) const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return this->operator != (Integer(l));
 #else
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, l) != 0;
@@ -249,7 +249,7 @@ namespace Givaro {
 
     int32_t Integer::operator > (const uint32_t l) const
     {
-#if GMP_LIMB_BITS == 32
+#if __GIVARO_SIZEOF_LONG == 4
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, l) > 0;
 #else
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, (uint64_t) l) > 0;
@@ -258,7 +258,7 @@ namespace Givaro {
 
     int32_t Integer::operator > (const int64_t l) const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG == 8
         return mpz_cmp_si((mpz_srcptr)&gmp_rep, l) > 0;
 #else
         return this->operator > (Integer(l));
@@ -267,7 +267,7 @@ namespace Givaro {
 
     int32_t Integer::operator > (const uint64_t l) const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG == 8
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, l) > 0;
 #else
         return this->operator > (Integer(l));
@@ -323,7 +323,7 @@ namespace Givaro {
 
     int32_t Integer::operator < (const uint32_t l) const
     {
-#if GMP_LIMB_BITS == 32
+#if __GIVARO_SIZEOF_LONG == 4
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, l) < 0;
 #else
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, (uint64_t) l) < 0;
@@ -332,7 +332,7 @@ namespace Givaro {
 
     int32_t Integer::operator < (const uint64_t l) const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG == 8
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, l) < 0;
 #else
         return this->operator < (Integer(l));
@@ -346,7 +346,7 @@ namespace Givaro {
 
     int32_t Integer::operator < (const int64_t l) const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG == 8
         return mpz_cmp_si((mpz_srcptr)&gmp_rep, l) < 0;
 #else
         return this->operator < (Integer(l));

--- a/src/kernel/gmp++/gmp++_int_compare.C
+++ b/src/kernel/gmp++/gmp++_int_compare.C
@@ -46,7 +46,7 @@ namespace Givaro {
 
     int32_t absCompare(const Integer &a, const uint64_t b)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return absCompare( a, Integer(b));
 #else
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), b);
@@ -64,7 +64,7 @@ namespace Givaro {
 
     int32_t absCompare(const Integer &a, const int64_t b)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return absCompare( a, Integer(b));
 #else
         return mpz_cmpabs_ui( (mpz_srcptr)&(a.gmp_rep), (uint64_t) std::abs(b));
@@ -112,7 +112,7 @@ namespace Givaro {
 
     int32_t Integer::operator != (const int64_t l) const
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return this->operator != (Integer(l));
 #else
         return mpz_cmp_si((mpz_srcptr)&gmp_rep, l) != 0;
@@ -121,7 +121,7 @@ namespace Givaro {
 
     int32_t Integer::operator != (const uint64_t l) const
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return this->operator != (Integer(l));
 #else
         return mpz_cmp_ui((mpz_srcptr)&gmp_rep, l) != 0;

--- a/src/kernel/gmp++/gmp++_int_cstor.C
+++ b/src/kernel/gmp++/gmp++_int_cstor.C
@@ -54,7 +54,7 @@ namespace Givaro {
     //-----------------------------Integer(int64_t n)
     Integer::Integer(int64_t n)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         // 64 bits is less than 20 digits
         char * tmp = new char[23];
         sprintf(tmp,"%lld",n);
@@ -68,7 +68,7 @@ namespace Givaro {
     //-----------------------------Integer(uint64_t n)
     Integer::Integer(uint64_t n)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         // 64 bits is less than 20 digits
         char * tmp = new char[23];
         sprintf(tmp,"%llu",n);

--- a/src/kernel/gmp++/gmp++_int_cstor.C
+++ b/src/kernel/gmp++/gmp++_int_cstor.C
@@ -54,7 +54,7 @@ namespace Givaro {
     //-----------------------------Integer(int64_t n)
     Integer::Integer(int64_t n)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         // 64 bits is less than 20 digits
         char * tmp = new char[23];
         sprintf(tmp,"%lld",n);
@@ -68,7 +68,7 @@ namespace Givaro {
     //-----------------------------Integer(uint64_t n)
     Integer::Integer(uint64_t n)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         // 64 bits is less than 20 digits
         char * tmp = new char[23];
         sprintf(tmp,"%llu",n);

--- a/src/kernel/gmp++/gmp++_int_div.C
+++ b/src/kernel/gmp++/gmp++_int_div.C
@@ -37,7 +37,7 @@ namespace Givaro {
     {
 
         if (isZero(res)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return divin(res,Integer(n));
 #else
         int32_t sgn = Givaro::sign(n);
@@ -50,7 +50,7 @@ namespace Givaro {
     Integer& Integer::divin(Integer& res, const uint64_t n)
     {
         if (isZero(res)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return divin(res,Integer(n));
 #else
         mpz_tdiv_q_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -71,7 +71,7 @@ namespace Givaro {
     Integer& Integer::div(Integer& res, const Integer& n1, const int64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return div(res,n1,Integer(n2));
 #else
         int32_t sgn = Givaro::sign(n2);
@@ -89,7 +89,7 @@ namespace Givaro {
     Integer& Integer::div(Integer& res, const Integer& n1, const uint64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return div(res,n1,Integer(n2));
 #else
         mpz_tdiv_q_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -111,7 +111,7 @@ namespace Givaro {
     Integer& Integer::divexact  (Integer& q, const Integer& n1, const uint64_t & n2)
     {
         if (isZero(n1)) return q = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return divexact(q,n1,Integer(n2));
 #else
         mpz_divexact_ui( (mpz_ptr)&(q.gmp_rep),
@@ -123,7 +123,7 @@ namespace Givaro {
     Integer& Integer::divexact  (Integer& q, const Integer& n1, const int64_t& n2)
     {
         if (isZero(n1)) return q = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return divexact(q,n1,Integer(n2));
 #else
         mpz_divexact_ui( (mpz_ptr)&(q.gmp_rep),
@@ -150,7 +150,7 @@ namespace Givaro {
     Integer  Integer::divexact  (const Integer& n1, const uint64_t& n2)
     {
         if (isZero(n1)) return Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return divexact(n1,Integer(n2));
 #else
         Integer q;
@@ -163,7 +163,7 @@ namespace Givaro {
     Integer  Integer::divexact  (const Integer& n1, const int64_t& n2)
     {
         if (isZero(n1)) return Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return divexact(n1,Integer(n2));
 #else
         Integer q;
@@ -190,7 +190,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return *this;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return *this /= Integer(l);
 #else
         mpz_tdiv_q_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -204,7 +204,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return *this;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return *this /= Integer(l);
 #else
         int32_t sgn = Givaro::sign(l);
@@ -232,7 +232,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return *this / Integer(l);
 #else
         Integer res;
@@ -248,7 +248,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return *this / Integer(l);
 #else
         Integer res;
@@ -275,7 +275,7 @@ namespace Givaro {
 
     Integer& Integer::divmod(Integer& q, int64_t & r, const Integer& a, const int64_t b)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         Integer res;
         divmod(q,res,a,Integer(b));
         r = (int64_t)res;
@@ -296,7 +296,7 @@ namespace Givaro {
 
     Integer& Integer::divmod(Integer& q, uint64_t & r, const Integer& a, const uint64_t b)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         Integer res;
         divmod(q,res,a,Integer(b));
         r = (uint64_t)res; // divmod already corrects when a<0
@@ -395,7 +395,7 @@ namespace Givaro {
 
     Integer& Integer::trem(Integer& r, const Integer &n , const uint64_t& d)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return trem(r,n,Integer(d));
 #else
         mpz_tdiv_r_ui((mpz_ptr)&(r.gmp_rep),
@@ -407,7 +407,7 @@ namespace Givaro {
 
     Integer& Integer::crem(Integer& r, const Integer &n , const uint64_t & d)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return crem(r,n,Integer(d));
 #else
         mpz_cdiv_r_ui((mpz_ptr)&(r.gmp_rep),
@@ -419,7 +419,7 @@ namespace Givaro {
 
     Integer& Integer::frem(Integer& r, const Integer &n , const uint64_t & d)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return frem(r,n,Integer(d));
 #else
         mpz_fdiv_r_ui((mpz_ptr)&(r.gmp_rep),
@@ -431,7 +431,7 @@ namespace Givaro {
 
     uint64_t Integer::trem(const Integer &n , const uint64_t& d)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (uint64_t)trem(n,Integer(d));
 #else
         return mpz_cdiv_ui( (mpz_srcptr)&(n.gmp_rep),
@@ -441,7 +441,7 @@ namespace Givaro {
 
     uint64_t Integer::crem(const Integer &n , const uint64_t & d)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (uint64_t)crem(n,Integer(d));
 #else
         return mpz_tdiv_ui( (mpz_srcptr)&(n.gmp_rep),
@@ -451,7 +451,7 @@ namespace Givaro {
 
     uint64_t Integer::frem(const Integer &n , const uint64_t & d)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (uint64_t)frem(n,Integer(d));
 #else
         return mpz_fdiv_ui( (mpz_srcptr)&(n.gmp_rep),

--- a/src/kernel/gmp++/gmp++_int_div.C
+++ b/src/kernel/gmp++/gmp++_int_div.C
@@ -37,7 +37,7 @@ namespace Givaro {
     {
 
         if (isZero(res)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return divin(res,Integer(n));
 #else
         int32_t sgn = Givaro::sign(n);
@@ -50,7 +50,7 @@ namespace Givaro {
     Integer& Integer::divin(Integer& res, const uint64_t n)
     {
         if (isZero(res)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return divin(res,Integer(n));
 #else
         mpz_tdiv_q_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -71,7 +71,7 @@ namespace Givaro {
     Integer& Integer::div(Integer& res, const Integer& n1, const int64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return div(res,n1,Integer(n2));
 #else
         int32_t sgn = Givaro::sign(n2);
@@ -89,7 +89,7 @@ namespace Givaro {
     Integer& Integer::div(Integer& res, const Integer& n1, const uint64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return div(res,n1,Integer(n2));
 #else
         mpz_tdiv_q_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -111,7 +111,7 @@ namespace Givaro {
     Integer& Integer::divexact  (Integer& q, const Integer& n1, const uint64_t & n2)
     {
         if (isZero(n1)) return q = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return divexact(q,n1,Integer(n2));
 #else
         mpz_divexact_ui( (mpz_ptr)&(q.gmp_rep),
@@ -123,7 +123,7 @@ namespace Givaro {
     Integer& Integer::divexact  (Integer& q, const Integer& n1, const int64_t& n2)
     {
         if (isZero(n1)) return q = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return divexact(q,n1,Integer(n2));
 #else
         mpz_divexact_ui( (mpz_ptr)&(q.gmp_rep),
@@ -150,7 +150,7 @@ namespace Givaro {
     Integer  Integer::divexact  (const Integer& n1, const uint64_t& n2)
     {
         if (isZero(n1)) return Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return divexact(n1,Integer(n2));
 #else
         Integer q;
@@ -163,7 +163,7 @@ namespace Givaro {
     Integer  Integer::divexact  (const Integer& n1, const int64_t& n2)
     {
         if (isZero(n1)) return Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return divexact(n1,Integer(n2));
 #else
         Integer q;
@@ -190,7 +190,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return *this;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return *this /= Integer(l);
 #else
         mpz_tdiv_q_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -204,7 +204,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return *this;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return *this /= Integer(l);
 #else
         int32_t sgn = Givaro::sign(l);
@@ -232,7 +232,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return *this / Integer(l);
 #else
         Integer res;
@@ -248,7 +248,7 @@ namespace Givaro {
         //    GivMathDivZero("[Integer::/]: division by zero");
         //  }
         if (isZero(*this)) return Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return *this / Integer(l);
 #else
         Integer res;
@@ -275,7 +275,7 @@ namespace Givaro {
 
     Integer& Integer::divmod(Integer& q, int64_t & r, const Integer& a, const int64_t b)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         Integer res;
         divmod(q,res,a,Integer(b));
         r = (int64_t)res;
@@ -296,7 +296,7 @@ namespace Givaro {
 
     Integer& Integer::divmod(Integer& q, uint64_t & r, const Integer& a, const uint64_t b)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         Integer res;
         divmod(q,res,a,Integer(b));
         r = (uint64_t)res; // divmod already corrects when a<0
@@ -395,7 +395,7 @@ namespace Givaro {
 
     Integer& Integer::trem(Integer& r, const Integer &n , const uint64_t& d)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return trem(r,n,Integer(d));
 #else
         mpz_tdiv_r_ui((mpz_ptr)&(r.gmp_rep),
@@ -407,7 +407,7 @@ namespace Givaro {
 
     Integer& Integer::crem(Integer& r, const Integer &n , const uint64_t & d)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return crem(r,n,Integer(d));
 #else
         mpz_cdiv_r_ui((mpz_ptr)&(r.gmp_rep),
@@ -419,7 +419,7 @@ namespace Givaro {
 
     Integer& Integer::frem(Integer& r, const Integer &n , const uint64_t & d)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return frem(r,n,Integer(d));
 #else
         mpz_fdiv_r_ui((mpz_ptr)&(r.gmp_rep),
@@ -431,7 +431,7 @@ namespace Givaro {
 
     uint64_t Integer::trem(const Integer &n , const uint64_t& d)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (uint64_t)trem(n,Integer(d));
 #else
         return mpz_cdiv_ui( (mpz_srcptr)&(n.gmp_rep),
@@ -441,7 +441,7 @@ namespace Givaro {
 
     uint64_t Integer::crem(const Integer &n , const uint64_t & d)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (uint64_t)crem(n,Integer(d));
 #else
         return mpz_tdiv_ui( (mpz_srcptr)&(n.gmp_rep),
@@ -451,7 +451,7 @@ namespace Givaro {
 
     uint64_t Integer::frem(const Integer &n , const uint64_t & d)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (uint64_t)frem(n,Integer(d));
 #else
         return mpz_fdiv_ui( (mpz_srcptr)&(n.gmp_rep),

--- a/src/kernel/gmp++/gmp++_int_div.C
+++ b/src/kernel/gmp++/gmp++_int_div.C
@@ -265,9 +265,21 @@ namespace Givaro {
         mpz_tdiv_qr( (mpz_ptr)&(q.gmp_rep), (mpz_ptr)&(r.gmp_rep),
                      (mpz_srcptr)&(a.gmp_rep), (mpz_srcptr)&(b.gmp_rep));
 
-        if (a<0 && r) {
-            subin(q,(int64_t)1) ;
-            r += b;
+        /* If r is negative (happen if a is negative, as sign(r) = sign(a)),
+         * we need to modify q and r to have a positive r.
+         */
+        if (r < 0)
+        {
+            if (b > 0)
+            {
+                subin (q, (uint64_t)1) ;
+                r += b;
+            }
+            else /* b is negative */
+            {
+                addin (q, (uint64_t)1) ;
+                r -= b;
+            }
         }
 
         return q;

--- a/src/kernel/gmp++/gmp++_int_misc.C
+++ b/src/kernel/gmp++/gmp++_int_misc.C
@@ -30,7 +30,7 @@ namespace Givaro {
     Integer fact ( uint64_t l)
     {
         Integer Res ;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         // factorial too large if l > 2^32 anyway
         uint32_t i(l);
         GIVARO_ASSERT( (uint64_t)i == l, "Factorial too large");
@@ -392,7 +392,7 @@ namespace Givaro {
     }
     Integer::operator int64_t() const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         Integer absThis = abs(*this);
         int64_t r = static_cast<int64_t>(absThis.operator uint32_t());
         absThis >>= 32;
@@ -404,7 +404,7 @@ namespace Givaro {
     }
     Integer::operator uint64_t() const
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         Integer absThis = abs(*this);
         uint64_t r = static_cast<uint64_t>(absThis.operator uint32_t());
         absThis >>= 32;

--- a/src/kernel/gmp++/gmp++_int_misc.C
+++ b/src/kernel/gmp++/gmp++_int_misc.C
@@ -393,11 +393,17 @@ namespace Givaro {
     Integer::operator int64_t() const
     {
 #if __GIVARO_SIZEOF_LONG < 8
-        Integer absThis = abs(*this);
-        int64_t r = static_cast<int64_t>(absThis.operator uint32_t());
-        absThis >>= 32;
-        r |= static_cast<int64_t>(absThis.operator uint32_t()) << 32;
-        return (*this < 0)? -r : r;
+        uint64_t u64 = this->operator uint64_t();
+        /* The following lines are adapted from the file mpz/get_si.c of GMP
+         * source code.
+         */
+        auto sgn = this->sign();
+        if (sgn > 0)
+            return u64 & INT64_MAX;
+        else if (sgn < 0)
+            return -1 - (int64_t) ((u64 -1) & INT64_MAX);
+        else
+            return 0;
 #else
         return mpz_get_si ( (mpz_srcptr)&gmp_rep);
 #endif

--- a/src/kernel/gmp++/gmp++_int_misc.C
+++ b/src/kernel/gmp++/gmp++_int_misc.C
@@ -30,7 +30,7 @@ namespace Givaro {
     Integer fact ( uint64_t l)
     {
         Integer Res ;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         // factorial too large if l > 2^32 anyway
         uint32_t i(l);
         GIVARO_ASSERT( (uint64_t)i == l, "Factorial too large");
@@ -392,7 +392,7 @@ namespace Givaro {
     }
     Integer::operator int64_t() const
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         Integer absThis = abs(*this);
         int64_t r = static_cast<int64_t>(absThis.operator uint32_t());
         absThis >>= 32;
@@ -404,7 +404,7 @@ namespace Givaro {
     }
     Integer::operator uint64_t() const
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         Integer absThis = abs(*this);
         uint64_t r = static_cast<uint64_t>(absThis.operator uint32_t());
         absThis >>= 32;

--- a/src/kernel/gmp++/gmp++_int_mod.C
+++ b/src/kernel/gmp++/gmp++_int_mod.C
@@ -37,7 +37,7 @@ namespace Givaro {
     Integer& Integer::modin(Integer& res, const uint64_t n)
     {
         if (isZero(res)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return modin(res,Integer(n));
 #else
         mpz_mod_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -47,7 +47,7 @@ namespace Givaro {
     Integer& Integer::modin(Integer& res, const int64_t n)
     {
         if (isZero(res)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return modin(res,Integer(n));
 #else
         if (n>0)
@@ -68,7 +68,7 @@ namespace Givaro {
     Integer& Integer::mod(Integer& res, const Integer& n1, const int64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mod(res,n1,Integer(n2));
 #else
         if (n2>0)
@@ -83,7 +83,7 @@ namespace Givaro {
     Integer& Integer::mod(Integer& res, const Integer& n1, const uint64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mod(res,n1,Integer(n2));
 #else
         mpz_mod_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -103,7 +103,7 @@ namespace Givaro {
     Integer& Integer::operator %= (const uint64_t l)
     {
         if (isZero(*this)) return *this;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return *this %= Integer(l);
 #else
 #  ifdef __GIVARO_DEBUG
@@ -120,7 +120,7 @@ namespace Givaro {
 
     Integer& Integer::operator %= (const int64_t l)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return *this %= Integer(l);
 #else
         if (isZero(*this)) return *this;
@@ -152,7 +152,7 @@ namespace Givaro {
     int64_t Integer::operator % (const uint64_t l) const
     {
         if (isZero(*this)) return 0U;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (int64_t) ((*this) % Integer(l));
 #else
         bool isneg = (*this)<0 ;

--- a/src/kernel/gmp++/gmp++_int_mod.C
+++ b/src/kernel/gmp++/gmp++_int_mod.C
@@ -37,7 +37,7 @@ namespace Givaro {
     Integer& Integer::modin(Integer& res, const uint64_t n)
     {
         if (isZero(res)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return modin(res,Integer(n));
 #else
         mpz_mod_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -47,7 +47,7 @@ namespace Givaro {
     Integer& Integer::modin(Integer& res, const int64_t n)
     {
         if (isZero(res)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return modin(res,Integer(n));
 #else
         if (n>0)
@@ -68,7 +68,7 @@ namespace Givaro {
     Integer& Integer::mod(Integer& res, const Integer& n1, const int64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mod(res,n1,Integer(n2));
 #else
         if (n2>0)
@@ -83,7 +83,7 @@ namespace Givaro {
     Integer& Integer::mod(Integer& res, const Integer& n1, const uint64_t n2)
     {
         if (isZero(n1)) return res = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mod(res,n1,Integer(n2));
 #else
         mpz_mod_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -103,7 +103,7 @@ namespace Givaro {
     Integer& Integer::operator %= (const uint64_t l)
     {
         if (isZero(*this)) return *this;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return *this %= Integer(l);
 #else
 #  ifdef __GIVARO_DEBUG
@@ -120,7 +120,7 @@ namespace Givaro {
 
     Integer& Integer::operator %= (const int64_t l)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return *this %= Integer(l);
 #else
         if (isZero(*this)) return *this;
@@ -152,7 +152,7 @@ namespace Givaro {
     int64_t Integer::operator % (const uint64_t l) const
     {
         if (isZero(*this)) return 0U;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (int64_t) ((*this) % Integer(l));
 #else
         bool isneg = (*this)<0 ;

--- a/src/kernel/gmp++/gmp++_int_mul.C
+++ b/src/kernel/gmp++/gmp++_int_mul.C
@@ -33,7 +33,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res = Integer::zero;
         if (isZero(res)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mulin(res,Integer(n));
 #else
         mpz_mul_si( (mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, n);
@@ -44,7 +44,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res = Integer::zero;
         if (isZero(res)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mulin(res,Integer(n));
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -63,7 +63,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = Integer::zero;
         if (isZero(n2)) return res = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mul(res,n1,Integer(n2));
 #else
         mpz_mul_si( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -74,7 +74,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = Integer::zero;
         if (isZero(n2)) return res = Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mul(res,n1,Integer(n2));
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -95,7 +95,7 @@ namespace Givaro {
     {
         if (&res == &b) return Integer::axpyin(res,a,x);
         if (isZero(a) || isZero(x)) return res = b;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return axpy(res,a,Integer(x),b);
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -115,7 +115,7 @@ namespace Givaro {
     Integer& Integer::axpyin(Integer& res, const Integer& a, const uint64_t x)
     {
         if (isZero(a) || isZero(x)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return axpyin(res,a,Integer(x));
 #else
         mpz_addmul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -136,7 +136,7 @@ namespace Givaro {
     {
         if (isZero(a) || isZero(x)) return res=b;
         if (&res == &b) return Integer::maxpyin(res,a,x);
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return maxpy(res,a,Integer(x),b);
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -158,7 +158,7 @@ namespace Givaro {
     {
         if (&res == &b) return Integer::axmyin(res,a,x);
         if (isZero(a) || isZero(x)) return Integer::neg(res,b);
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return axmy(res,a,Integer(x),b);
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -191,7 +191,7 @@ namespace Givaro {
     Integer& Integer::maxpyin(Integer& res, const Integer& a, const uint64_t x)
     {
         if (isZero(a) || isZero(x)) return res;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return maxpyin(res,a,Integer(x));
 #else
         mpz_submul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -213,7 +213,7 @@ namespace Givaro {
     {
         if (l==0) return *this = Integer::zero;
         if (isZero(*this)) return *this;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mulin(*this,Integer(l));
 #else
         mpz_mul_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -225,7 +225,7 @@ namespace Givaro {
     {
         if (l==0) return *this =Integer::zero;
         if (isZero(*this)) return *this;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return mulin(*this,Integer(l));
 #else
         mpz_mul_si( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -247,7 +247,7 @@ namespace Givaro {
     {
         if (l==0) return Integer::zero;
         if (isZero(*this)) return Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) * Integer(l);
 #else
         Integer res;
@@ -260,7 +260,7 @@ namespace Givaro {
     {
         if (l==0) return Integer::zero;
         if (isZero(*this)) return Integer::zero;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) * Integer(l);
 #else
         Integer res;

--- a/src/kernel/gmp++/gmp++_int_mul.C
+++ b/src/kernel/gmp++/gmp++_int_mul.C
@@ -33,7 +33,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res = Integer::zero;
         if (isZero(res)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mulin(res,Integer(n));
 #else
         mpz_mul_si( (mpz_ptr)&res.gmp_rep, (mpz_ptr)&res.gmp_rep, n);
@@ -44,7 +44,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res = Integer::zero;
         if (isZero(res)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mulin(res,Integer(n));
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -63,7 +63,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = Integer::zero;
         if (isZero(n2)) return res = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mul(res,n1,Integer(n2));
 #else
         mpz_mul_si( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -74,7 +74,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return res = Integer::zero;
         if (isZero(n2)) return res = Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mul(res,n1,Integer(n2));
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -95,7 +95,7 @@ namespace Givaro {
     {
         if (&res == &b) return Integer::axpyin(res,a,x);
         if (isZero(a) || isZero(x)) return res = b;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return axpy(res,a,Integer(x),b);
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -115,7 +115,7 @@ namespace Givaro {
     Integer& Integer::axpyin(Integer& res, const Integer& a, const uint64_t x)
     {
         if (isZero(a) || isZero(x)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return axpyin(res,a,Integer(x));
 #else
         mpz_addmul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -136,7 +136,7 @@ namespace Givaro {
     {
         if (isZero(a) || isZero(x)) return res=b;
         if (&res == &b) return Integer::maxpyin(res,a,x);
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return maxpy(res,a,Integer(x),b);
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -158,7 +158,7 @@ namespace Givaro {
     {
         if (&res == &b) return Integer::axmyin(res,a,x);
         if (isZero(a) || isZero(x)) return Integer::neg(res,b);
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return axmy(res,a,Integer(x),b);
 #else
         mpz_mul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -191,7 +191,7 @@ namespace Givaro {
     Integer& Integer::maxpyin(Integer& res, const Integer& a, const uint64_t x)
     {
         if (isZero(a) || isZero(x)) return res;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return maxpyin(res,a,Integer(x));
 #else
         mpz_submul_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&a.gmp_rep, x);
@@ -213,7 +213,7 @@ namespace Givaro {
     {
         if (l==0) return *this = Integer::zero;
         if (isZero(*this)) return *this;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mulin(*this,Integer(l));
 #else
         mpz_mul_ui( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -225,7 +225,7 @@ namespace Givaro {
     {
         if (l==0) return *this =Integer::zero;
         if (isZero(*this)) return *this;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return mulin(*this,Integer(l));
 #else
         mpz_mul_si( (mpz_ptr)&(gmp_rep), (mpz_ptr)&gmp_rep, l);
@@ -247,7 +247,7 @@ namespace Givaro {
     {
         if (l==0) return Integer::zero;
         if (isZero(*this)) return Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) * Integer(l);
 #else
         Integer res;
@@ -260,7 +260,7 @@ namespace Givaro {
     {
         if (l==0) return Integer::zero;
         if (isZero(*this)) return Integer::zero;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) * Integer(l);
 #else
         Integer res;

--- a/src/kernel/gmp++/gmp++_int_pow.C
+++ b/src/kernel/gmp++/gmp++_int_pow.C
@@ -30,7 +30,7 @@ namespace Givaro {
 
     Integer& pow(Integer& Res, const Integer& n, const uint64_t p)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         // exponent too large if p > 2^32 anyway
         uint32_t i(p);
         GIVARO_ASSERT( (uint64_t)i == p, "Exponent too large");
@@ -43,7 +43,7 @@ namespace Givaro {
 
     Integer& pow(Integer& Res, const uint64_t n, const uint64_t p)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return pow(Res,n,Integer(p));
 #else
         mpz_ui_pow_ui( (mpz_ptr)&(Res.gmp_rep), n, p);
@@ -85,7 +85,7 @@ namespace Givaro {
 
     Integer& powmod(Integer& Res, const Integer& n, const uint64_t p, const Integer& m)
     {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return powmod(Res,n,Integer(p),m);
 #else
         mpz_powm_ui( (mpz_ptr)&(Res.gmp_rep), (mpz_srcptr)&n.gmp_rep, p, (mpz_srcptr)&m.gmp_rep);

--- a/src/kernel/gmp++/gmp++_int_pow.C
+++ b/src/kernel/gmp++/gmp++_int_pow.C
@@ -30,7 +30,7 @@ namespace Givaro {
 
     Integer& pow(Integer& Res, const Integer& n, const uint64_t p)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         // exponent too large if p > 2^32 anyway
         uint32_t i(p);
         GIVARO_ASSERT( (uint64_t)i == p, "Exponent too large");
@@ -43,7 +43,7 @@ namespace Givaro {
 
     Integer& pow(Integer& Res, const uint64_t n, const uint64_t p)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return pow(Res,n,Integer(p));
 #else
         mpz_ui_pow_ui( (mpz_ptr)&(Res.gmp_rep), n, p);
@@ -85,7 +85,7 @@ namespace Givaro {
 
     Integer& powmod(Integer& Res, const Integer& n, const uint64_t p, const Integer& m)
     {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return powmod(Res,n,Integer(p),m);
 #else
         mpz_powm_ui( (mpz_ptr)&(Res.gmp_rep), (mpz_srcptr)&n.gmp_rep, p, (mpz_srcptr)&m.gmp_rep);

--- a/src/kernel/gmp++/gmp++_int_sub.C
+++ b/src/kernel/gmp++/gmp++_int_sub.C
@@ -34,7 +34,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return negin(res = n);
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return subin(res,Integer(n));
 #else
         int32_t sgn = Givaro::sign(n);
@@ -47,7 +47,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return negin(res = n);
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return subin(res,Integer(n));
 #else
         mpz_sub_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -66,7 +66,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return negin(res = n2);
         if (isZero(n2)) return res = n1;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return sub(res,n1,Integer(n2));
 #else
         int32_t sgn = Givaro::sign(n2);
@@ -79,7 +79,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return negin(res = n2);
         if (isZero(n2)) return res = n1;
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return sub(res,n1,Integer(n2));
 #else
         mpz_sub_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -113,7 +113,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(-Integer(l));
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) -= Integer(l);
 #else
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
@@ -127,7 +127,7 @@ namespace Givaro {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(-Integer(l));
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) -= Integer(l);
 #else
         int32_t sgn = Givaro::sign(l);
@@ -153,7 +153,7 @@ namespace Givaro {
         if (l==0) return *this;
         if (isZero(*this)) return -Integer(l);
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) - Integer(l);
 #else
         Integer res;
@@ -167,7 +167,7 @@ namespace Givaro {
         if (l==0) return *this;
         if (isZero(*this)) return -Integer(l);
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
         return (*this) - Integer(l);
 #else
         Integer res;

--- a/src/kernel/gmp++/gmp++_int_sub.C
+++ b/src/kernel/gmp++/gmp++_int_sub.C
@@ -34,7 +34,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return negin(res = n);
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return subin(res,Integer(n));
 #else
         int32_t sgn = Givaro::sign(n);
@@ -47,7 +47,7 @@ namespace Givaro {
     {
         if (isZero(n)) return res;
         if (isZero(res)) return negin(res = n);
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return subin(res,Integer(n));
 #else
         mpz_sub_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&res.gmp_rep, n);
@@ -66,7 +66,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return negin(res = n2);
         if (isZero(n2)) return res = n1;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return sub(res,n1,Integer(n2));
 #else
         int32_t sgn = Givaro::sign(n2);
@@ -79,7 +79,7 @@ namespace Givaro {
     {
         if (isZero(n1)) return negin(res = n2);
         if (isZero(n2)) return res = n1;
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return sub(res,n1,Integer(n2));
 #else
         mpz_sub_ui( (mpz_ptr)&res.gmp_rep, (mpz_srcptr)&n1.gmp_rep, n2);
@@ -113,7 +113,7 @@ namespace Givaro {
     {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(-Integer(l));
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) -= Integer(l);
 #else
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
@@ -127,7 +127,7 @@ namespace Givaro {
         if (l==0) return *this;
         if (isZero(*this)) return logcpy(-Integer(l));
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) -= Integer(l);
 #else
         int32_t sgn = Givaro::sign(l);
@@ -153,7 +153,7 @@ namespace Givaro {
         if (l==0) return *this;
         if (isZero(*this)) return -Integer(l);
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) - Integer(l);
 #else
         Integer res;
@@ -167,7 +167,7 @@ namespace Givaro {
         if (l==0) return *this;
         if (isZero(*this)) return -Integer(l);
         //   Rep (res.gmp_rep)( MAX(SZ_REP(gmp_rep),1) );
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
         return (*this) - Integer(l);
 #else
         Integer res;

--- a/src/kernel/recint/ruconvert.h
+++ b/src/kernel/recint/ruconvert.h
@@ -44,7 +44,7 @@ namespace RecInt
 
         reset(a);
         for (i = 0; i < NBLIMB<K>::value; i++) {
-#if __GIVARO_SIZEOF_LONG != 8
+#if __GIVARO_SIZEOF_LONG < 8
             limb l = c.get_ui(); c >>= 32;
             l |= (limb(c.get_ui()) << 32);
             set_limb(a, l, i); c >>= 32;
@@ -63,7 +63,7 @@ namespace RecInt
     inline mpz_class& ruint_to_mpz(mpz_class& a, const ruint<K>& b) {
         //         a = 0;
         //         for (auto it(b.rbegin()); it != b.rend(); ++it) {
-        // #if __GIVARO_SIZEOF_LONG != 8
+        // #if __GIVARO_SIZEOF_LONG < 8
         // 		    // GMP does not handle uint64_t, need to break it
         //             a <<= 32;
         //             a ^= static_cast<uint32_t>(mp_limb_t((*it) >> 32));

--- a/src/kernel/recint/ruconvert.h
+++ b/src/kernel/recint/ruconvert.h
@@ -44,7 +44,7 @@ namespace RecInt
 
         reset(a);
         for (i = 0; i < NBLIMB<K>::value; i++) {
-#if GMP_LIMB_BITS != 64
+#if __GIVARO_SIZEOF_LONG != 8
             limb l = c.get_ui(); c >>= 32;
             l |= (limb(c.get_ui()) << 32);
             set_limb(a, l, i); c >>= 32;
@@ -63,7 +63,7 @@ namespace RecInt
     inline mpz_class& ruint_to_mpz(mpz_class& a, const ruint<K>& b) {
         //         a = 0;
         //         for (auto it(b.rbegin()); it != b.rend(); ++it) {
-        // #if GMP_LIMB_BITS != 64
+        // #if __GIVARO_SIZEOF_LONG != 8
         // 		    // GMP does not handle uint64_t, need to break it
         //             a <<= 32;
         //             a ^= static_cast<uint32_t>(mp_limb_t((*it) >> 32));


### PR DESCRIPTION
The calls to `mpz_XXX_ui` and `mpz_XXX_si` used to be protected by macros of the form `GMP_LIMBS_BITS != 64`, which is   not always equivalent to `__GIVARO_SIZEOF_LONG != 8`, e.g. on x32 arch. See #187

This PR proposes to switch to testing the size of long which is the actual question to ask, since the API of these gmp functions use `long` or `unsigned long`.
