### PR TITLE
Fix dom_power issue on 32bit machine

### DIFF
--- a/src/kernel/system/givpower.h
+++ b/src/kernel/system/givpower.h
@@ -71,11 +71,11 @@ namespace Givaro {
 
     //! dom_power
     template<class D, class TT>
-    TT& dom_power(TT& res, const TT& n, long l, const D& F)
+    TT& dom_power(TT& res, const TT& n, uint64_t l, const D& F)
     {
         if (l == 0) return F.assign(res,F.one) ;
 
-        unsigned long p = (unsigned long) l ;
+        uint64_t p = l;
         bool is_assg = false ;
 
         TT puiss; F.init(puiss); F.assign(puiss,n) ;


### PR DESCRIPTION
dom_power is used to compute `n^l`. In the code of master `l` is taken as an long.
This causes some issues on 32 bits machine (see for exemple linbox-team/linbox#293).

In this PR, I propose to switch the type from long to uint64_t.

First, I think an unsigned type should be used: in the code of dom_power, the argument `l` is immediatly cast to an `unsigned long` and the bit representation of this value is used to perform a double and add algorithm. It means that calling dom_power with a negative `l` is incorrect (except in the case where order(n) = ULONG_MAX+1).

Second, I think that using a type with a fixed size is clearer: just looking at the prototype of the function tells you the maximum possible value of the exponent.

This PR fixes  linbox-team/linbox#293