### PR TITLE
Use PROJECT_NUMBER instead of FILE_VERSION_FILTER for doxygen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,7 @@ examples/Matrix/Makefile
 tests/Makefile
 docs/Makefile
 givaro.pc
+$DOXYGEN_CONFIG_FILES
 ])
 AC_CONFIG_FILES([givaro-config],[chmod +x givaro-config])
 AC_OUTPUT

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1637,7 +1637,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # toolkit from AT&T and Lucent Bell Labs. The other options in this section
 # have no effect if this option is set to NO (the default)
 
-HAVE_DOT               = NO
+HAVE_DOT               = @HAVE_DOT@
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is
 # allowed to run in parallel. When set to 0 (the default) doxygen will

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -32,7 +32,7 @@ PROJECT_NAME           = Givaro
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = @VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/docs/Doxyfile.mod
+++ b/docs/Doxyfile.mod
@@ -590,7 +590,7 @@ SHOW_NAMESPACES        = YES
 # provided by doxygen. Whatever the program writes to standard output
 # is used as the file version. See the manual for examples.
 
-FILE_VERSION_FILTER    = "../givaro-config --version"
+FILE_VERSION_FILTER    =
 
 # The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
 # by doxygen. The layout file controls the global structure of the generated

--- a/docs/DoxyfileDev.in
+++ b/docs/DoxyfileDev.in
@@ -1637,7 +1637,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # toolkit from AT&T and Lucent Bell Labs. The other options in this section
 # have no effect if this option is set to NO (the default)
 
-HAVE_DOT               = NO
+HAVE_DOT               = @HAVE_DOT@
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is
 # allowed to run in parallel. When set to 0 (the default) doxygen will

--- a/docs/DoxyfileDev.in
+++ b/docs/DoxyfileDev.in
@@ -32,7 +32,7 @@ PROJECT_NAME           = Givaro
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = @VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/macros/givaro-doc.m4
+++ b/macros/givaro-doc.m4
@@ -63,14 +63,9 @@ AS_IF([test x$WITH_DOC = xyes],[
     (dot -V) < /dev/null > /dev/null 2>&1 || res=no
     AC_MSG_RESULT([$res])
     AS_MKDIR_P([docs])
-    AS_IF([test $res = yes],
-    [
-    sed 's/^HAVE_DOT.*/HAVE_DOT = YES/' "$srcdir"/docs/Doxyfile.mod > docs/Doxyfile
-    sed 's/^HAVE_DOT.*/HAVE_DOT = YES/' "$srcdir"/docs/DoxyfileDev.mod > docs/DoxyfileDev
-    ],
-    [ cp "$srcdir"/docs/Doxyfile.mod docs/Doxyfile ;
-    cp "$srcdir"/docs/DoxyfileDev.mod docs/DoxyfileDev
-    ])
+    AS_IF([test $res = yes], [HAVE_DOT=YES], [HAVE_DOT=NO])
+    AC_SUBST([HAVE_DOT])
+    DOXYGEN_CONFIG_FILES="docs/Doxyfile docs/DoxyfileDev"
 
   ], [
   AS_IF([(doxygen --version) < /dev/null > /dev/null 2>&1],


### PR DESCRIPTION
This is a partial fix for #199, which (as identified in https://github.com/doxygen/doxygen/issues/9491#issuecomment-1206195687) has two underlying causes: a regression between doxygen 1.9.1 and 1.9.4 that will be fixed in 1.9.5, and the use of `FILE_VERSION_FILTER` was causing `givaro-config` to be called for each file, which is very expensive.

Instead, we use `PROJECT_NUMBER` to inject the current version number into the documentation.  This is accomplished using `AC_OUTPUT`, so we take the opportunity to use this for setting `HAVE_DOT` as well.