### PR TITLE
Implement Polynomial Middle product

### DIFF
--- a/src/library/poly1/Makefile.am
+++ b/src/library/poly1/Makefile.am
@@ -25,6 +25,7 @@ pkginclude_HEADERS=        \
 	givpoly1axpy.inl	   \
 	givpoly1gcd.inl		   \
 	givpoly1kara.inl	   \
+	givpoly1midmul.inl	   \
 	givpoly1cstor.inl	   \
 	givpoly1io.inl		   \
 	givpoly1misc.inl	   \

--- a/src/library/poly1/givpoly1dense.h
+++ b/src/library/poly1/givpoly1dense.h
@@ -260,8 +260,12 @@ namespace Givaro {
         Rep& stdmul( Rep& R, const Rep& P, const Rep& Q) const;
         // Forces first level of Karatsuba multiplication algorithm
         Rep& karamul( Rep& R, const Rep& P, const Rep& Q) const;
+        // Generic middle product with dynamic recursive choices between stdmidmul and karamidmul
+        Rep& midmul ( Rep& R, const Rep& P, const Rep& Q ) const;
         // Forces standard middle product
         Rep& stdmidmul( Rep& R, const Rep& P, const Rep& Q) const;
+        // Forces first level of Karatsuba balanced middle product algorithm
+        Rep& karamidmul( Rep& R, const Rep& P, const Rep& Q ) const;
 
         // Compute truncated mul: only the coefficients inside
         // the degree interval, included
@@ -417,10 +421,20 @@ namespace Givaro {
                       const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
                       const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend ) const;
 
+        // Middle product only between iterator intervals
+        Rep& midmul( Rep& R, const RepIterator Rbeg, const RepIterator Rend,
+                  const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
+                  const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend ) const;
+
         // Middle product of P of size m+n-1 and Q of size n: MP(P,Q)=((PQ) quo X^(n-1)) mod X^m of size m
         Rep& stdmidmul( Rep& R, const RepIterator Rbeg, const RepIterator Rend,
                         const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
                         const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend) const;
+
+        // Karastuba balanced middle product between iterator bounds
+        Rep& karamidmul( Rep& R, const RepIterator Rbeg, const RepIterator Rend,
+                         const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
+                         const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend) const;
 
         Rep& sqr( Rep& R, const RepIterator Rbeg, const RepIterator Rend,
                   const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend) const;

--- a/src/library/poly1/givpoly1dense.h
+++ b/src/library/poly1/givpoly1dense.h
@@ -260,6 +260,8 @@ namespace Givaro {
         Rep& stdmul( Rep& R, const Rep& P, const Rep& Q) const;
         // Forces first level of Karatsuba multiplication algorithm
         Rep& karamul( Rep& R, const Rep& P, const Rep& Q) const;
+        // Forces standard middle product
+        Rep& stdmidmul( Rep& R, const Rep& P, const Rep& Q) const;
 
         // Compute truncated mul: only the coefficients inside
         // the degree interval, included
@@ -414,6 +416,11 @@ namespace Givaro {
         Rep& karamul( Rep& R, const RepIterator Rbeg, const RepIterator Rend,
                       const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
                       const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend ) const;
+
+        // Middle product of P of size m+n-1 and Q of size n: MP(P,Q)=((PQ) quo X^(n-1)) mod X^m of size m
+        Rep& stdmidmul( Rep& R, const RepIterator Rbeg, const RepIterator Rend,
+                        const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
+                        const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend) const;
 
         Rep& sqr( Rep& R, const RepIterator Rbeg, const RepIterator Rend,
                   const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend) const;

--- a/src/library/poly1/givpoly1denseops.inl
+++ b/src/library/poly1/givpoly1denseops.inl
@@ -12,6 +12,7 @@
 #include "givaro/givpoly1addsub.inl"
 #include "givaro/givpoly1muldiv.inl"
 #include "givaro/givpoly1kara.inl"
+#include "givaro/givpoly1midmul.inl"
 #include "givaro/givpoly1axpy.inl"
 #include "givaro/givpoly1io.inl"
 #include "givaro/givpoly1gcd.inl"

--- a/src/library/poly1/givpoly1midmul.inl
+++ b/src/library/poly1/givpoly1midmul.inl
@@ -1,0 +1,77 @@
+// ==========================================================================
+// Copyright(c)'1994-2022 by The Givaro group
+// This file is part of Givaro.
+// Givaro is governed by the CeCILL-B license under French law
+// and abiding by the rules of distribution of free software.
+// see the COPYRIGHT file for more details.
+// Authors: B. Grenet
+//
+// Generalized middle product:
+// For polynomials P of size m+n-1 and Q of size n, define their
+// middle product MP(P,Q) as the central m coefficients of P*Q
+// that is MP(P,Q) = (PQ div X^(n-1)) mod X^m
+//
+// Balanced case: m = n
+// ==========================================================================
+#ifndef __GIVARO_poly1_midmul_INL
+#define __GIVARO_poly1_midmul_INL
+
+namespace Givaro {
+
+#ifndef KARA_THRESHOLD
+#define KARA_THRESHOLD 50
+#endif
+
+    // forces standard middle product
+    template <class Domain>
+    inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::stdmidmul(
+        Rep& R, const Rep& P, const Rep& Q ) const
+    {
+        const size_t sP = P.size();
+        const size_t sQ = Q.size();
+        const size_t sR = sP-sQ+1;
+        if (sR != R.size()) R.resize(sR);
+
+        stdmidmul(R, R.begin(), R.end(),
+               P, P.begin(), P.end(),
+               Q, Q.begin(), Q.end());
+
+        return setdegree(R);
+    }
+
+    // Standard middle product between iterator bounds
+    template <class Domain>
+    inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::stdmidmul(
+        Rep& R, const RepIterator Rbeg, const RepIterator Rend,
+        const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
+        const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend )
+        const {
+
+        if (Rbeg == Rend) return R;
+
+        RepConstIterator ai=Pbeg,aig=Pbeg,bi=Qend; --bi;
+        RepIterator ri=Rbeg;
+        if (_domain.isZero(*bi))
+            for(; (ai != Pend) && (ri != Rend); ++ai,++ri)
+                _domain.assign(*ri,_domain.zero);
+        else
+            for(; (ai!=Pend) && (ri!=Rend);++ai,++ri)
+                if (_domain.isZero(*ai))
+                    _domain.assign(*ri, _domain.zero);
+                else
+                    _domain.mul(*ri,*ai,*bi);
+
+        for(;ri!=Rend;++ri)
+            _domain.assign(*ri,_domain.zero);
+
+        for(--bi,++aig; (aig!=Pend) && (bi>=Qbeg);++aig,--bi)
+            if (! _domain.isZero(*bi))
+                for(ri=Rbeg,ai=aig; (ai!=Pend) && (ri!=Rend);++ai,++ri)
+                    _domain.axpyin(*ri,*ai,*bi);
+        return R;
+    }
+
+}
+#endif // __GIVARO_poly1_mid_INL
+/* -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+// vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s

--- a/src/library/poly1/givpoly1midmul.inl
+++ b/src/library/poly1/givpoly1midmul.inl
@@ -1,4 +1,4 @@
-// ==========================================================================
+ // ==========================================================================
 // Copyright(c)'1994-2022 by The Givaro group
 // This file is part of Givaro.
 // Givaro is governed by the CeCILL-B license under French law
@@ -22,6 +22,27 @@ namespace Givaro {
 #define KARA_THRESHOLD 50
 #endif
 
+    // Generic middle product with dynamic recursive choices between stdmidmul and karamidmul
+    template <class Domain>
+    inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::midmul(
+        Rep& R, const Rep& P, const Rep& Q ) const
+    {
+        size_t sR = R.size();
+        size_t sP = P.size();
+        size_t sQ = Q.size();
+        if ((sQ ==0) || (sP ==0)) { R.resize(0); return R; }
+        if (sR != sP-sQ+1) R.resize(sR = sP-sQ+1);
+
+        // Generic middle product handler
+        // Can use e.g. Karatsuba multiplication
+        midmul(R, R.begin(), R.end(),
+               P, P.begin(), P.end(),
+               Q, Q.begin(), Q.end());
+
+        return setdegree(R);
+
+    }
+
     // forces standard middle product
     template <class Domain>
     inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::stdmidmul(
@@ -39,6 +60,101 @@ namespace Givaro {
         return setdegree(R);
     }
 
+    // forces FIRST recursive level with Karatsuba algorithm
+    template <class Domain>
+    inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::karamidmul(
+        Rep& R, const Rep& P, const Rep& Q ) const
+    {
+        // Assumes sP = 2*sQ-1; otherwise undefined behavior
+        const size_t sP = P.size();
+        const size_t sQ = Q.size();
+        const size_t sR = sP-sQ+1;
+        if (sR != R.size()) R.resize(sR);
+
+        karamidmul(R, R.begin(), R.end(),
+               P, P.begin(), P.end(),
+               Q, Q.begin(), Q.end());
+
+        return setdegree(R);
+    }
+
+    // Generic midmul that dispatches to balanced midmul
+    // Multiplies between the iterator bounds.
+    template <class Domain>
+    inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::midmul(
+        Rep& R, const RepIterator Rbeg, const RepIterator Rend,
+        const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
+        const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend)
+        const {
+
+            const ssize_t n = (ssize_t) (Qend-Qbeg);
+            const ssize_t m = (ssize_t) (Pend-Pbeg) - n + 1;
+
+        //std::cerr << "Entering GenMidMul with "
+        //          << "P[" << (Pbeg-P.begin()) << ":" << (Pend-P.begin()) << "/" << (P.end()-P.begin()) << "] × "
+        //          << "Q[" << (Qbeg-Q.begin()) << ":" << (Qend-Q.begin()) << "/" << (Q.end()-Q.begin()) << "] → "
+        //          << "R[" << (Rbeg-R.begin()) << ":" << (Rend-R.begin()) << "/" << (R.end()-R.begin()) << "] : "
+        //          << "m=" << m << ", n=" << n << std::endl;
+
+            if ( std::min(m,n) <= KARA_THRESHOLD)
+                return stdmidmul(R, Rbeg, Rend,
+                                 P, Pbeg, Pend,
+                                 Q, Qbeg, Qend);
+
+            if (m == n)
+                return karamidmul(R, Rbeg, Rend,
+                                  P, Pbeg, Pend,
+                                  Q, Qbeg, Qend);
+
+            if (m > n) {
+                ssize_t i = 0;
+                for (; i <= m-n; i+=n)
+                    karamidmul(R, Rbeg+i, Rbeg+i+n,
+                               P, Pbeg+i, Pbeg+i+2*n-1,
+                               Q, Qbeg, Qend);
+
+                if (i < m)
+                    midmul(R, Rbeg + i, Rend,
+                           P, Pbeg + i, Pend,
+                           Q, Qbeg, Qend);
+
+                return R;
+            }
+
+            // m < n
+
+            RepConstIterator Pe = Pend, Qb = Qbeg;
+
+            karamidmul(R, Rbeg, Rend,
+                       P, Pe-(2*m-1), Pe,
+                       Q, Qb, Qb+m);
+
+            Pe -= m; Qb += m;
+
+            Rep Tmp; Tmp.resize(m);
+
+            for(;Qb <= Qend-m; Pe-=m, Qb+=m) {
+                karamidmul(Tmp, Tmp.begin(), Tmp.end(),
+                           P, Pe-(2*m-1), Pe,
+                           Q, Qb, Qb+m);
+                RepIterator Ri = Rbeg;
+                for( RepConstIterator Ti=Tmp.begin(); Ti != Tmp.end(); ++Ti,++Ri)
+                    _domain.addin(*Ri, *Ti);
+            }
+
+            if (Qb < Qend) {
+                midmul(Tmp, Tmp.begin(), Tmp.end(),
+                       P, Pbeg, Pe,
+                       Q, Qb, Qend);
+                RepIterator Ri = Rbeg;
+                for( RepConstIterator Ti=Tmp.begin(); Ti != Tmp.end(); ++Ti,++Ri)
+                    _domain.addin(*Ri, *Ti);
+            }
+
+            return R;
+
+    }
+
     // Standard middle product between iterator bounds
     template <class Domain>
     inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::stdmidmul(
@@ -46,6 +162,12 @@ namespace Givaro {
         const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
         const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend )
         const {
+
+        //std::cerr << "Entering StdMidMul with "
+        //          << "P[" << (Pbeg-P.begin()) << ":" << (Pend-P.begin()) << "/" << (P.end()-P.begin()) << "] × "
+        //          << "Q[" << (Qbeg-Q.begin()) << ":" << (Qend-Q.begin()) << "/" << (Q.end()-Q.begin()) << "] → "
+        //          << "R[" << (Rbeg-R.begin()) << ":" << (Rend-R.begin()) << "/" << (R.end()-R.begin()) << "]"
+        //          << std::endl;
 
         if (Rbeg == Rend) return R;
 
@@ -68,8 +190,97 @@ namespace Givaro {
             if (! _domain.isZero(*bi))
                 for(ri=Rbeg,ai=aig; (ai!=Pend) && (ri!=Rend);++ai,++ri)
                     _domain.axpyin(*ri,*ai,*bi);
+
         return R;
     }
+
+    // Karastuba balanced middle product between iterator bounds
+    template <class Domain>
+    inline typename Poly1Dom<Domain,Dense>::Rep& Poly1Dom<Domain,Dense>::karamidmul(
+        Rep& R, const RepIterator Rbeg, const RepIterator Rend,
+        const Rep& P, const RepConstIterator Pbeg, const RepConstIterator Pend,
+        const Rep& Q, const RepConstIterator Qbeg, const RepConstIterator Qend )
+        const {
+
+        // Assumes Pend-Pbeg == 2*(Qend-Qbeg)-1
+        // Otherwise: undefined behavior!
+        if (Rbeg == Rend) return R;
+
+        if (Qend-Qbeg == 1) {
+            _domain.mul(*Rbeg, *Pbeg, *Qbeg);
+            return R;
+        }
+
+        // Initialize R to zero
+        for(RepIterator ri=Rbeg; ri!= Rend; ++ri) _domain.assign(*ri,_domain.zero);
+
+        const ssize_t n = (ssize_t) (Qend-Qbeg);
+        const ssize_t n0 = n>>1;
+        const ssize_t n1 = n0 + (n&1);
+        const RepConstIterator P0end=Pbeg+2*n1-1, // end of P0
+                               P1beg=Pbeg+n1, // beg of P1
+                               P1plus=Pbeg+3*n1-1, // end of P1+
+                               P1minus=Pbeg+n1+2*n0-1, // end of P1-
+                               P2beg=Pbeg+2*n1, // beg of P2
+                               Qmid=Qbeg+n0; // mid of Q = end of Q0 = beg of Q1
+        const RepIterator      Rmid=Rbeg+n1; // mid of R = end of R0 = beg of R1
+
+        //std::cerr << "Entering KaraMidMul " << (Pend-Pbeg) << "×" << (Qend-Qbeg) << "→" << (Rend-Rbeg) << std::endl;
+        //std::cerr << "P0 = slice(P," << (Pbeg-P.begin()) << "," << (P0end-P.begin()) << ")" << std::endl;
+        //std::cerr << "P1m= slice(P," << (P1beg-P.begin()) << "," << (P1minus-P.begin()) << ")" << std::endl;
+        //std::cerr << "P1p= slice(P," << (P1beg-P.begin()) << "," << (P1plus-P.begin()) << ")" << std::endl;
+        //std::cerr << "P2 = slice(P," << (P2beg-P.begin()) << "," << (Pend-P.begin()) << ")" << std::endl;
+        //std::cerr << "Q0 = slice(Q," << (Qbeg-Q.begin()) << "," << (Qmid-Q.begin()) << ")" << std::endl;
+        //std::cerr << "Q1 = slice(Q," << (Qmid-Q.begin()) << "," << (Qend-Q.begin()) << ")" << std::endl;
+        //std::cerr << "R0 = slice(R," << (Rbeg-R.begin()) << "," << (Rmid-R.begin()) << ")" << std::endl;
+        //std::cerr << "R1 = slice(R," << (Rmid-R.begin()) << "," << (Rend-R.begin()) << ")" << std::endl;
+
+
+        Rep TMP, Rtmp;
+
+        // R0 ← S0 = MP(P1+ + P0, Q1)
+        TMP.resize(2*n1-1);
+        RepIterator TMPi=TMP.begin();
+        for(RepConstIterator P0i=Pbeg, P1i = P1beg;(P0i!=P0end) && (P1i!=P1plus); ++P0i, ++P1i, ++TMPi)
+            _domain.add(*TMPi, *P0i, *P1i);
+        midmul(R, Rbeg, Rmid,
+               TMP, TMP.begin(), TMP.end(),
+               Q, Qmid, Qend);
+
+        // R1 ← S1 = MP(P1- + P2, Q0)
+        TMP.resize(2*n0-1);
+        TMPi = TMP.begin();
+        for (RepConstIterator P1i = P1beg, P2i = P2beg; (P1i!=P1minus) && (P2i!=Pend); ++P1i, ++P2i, ++TMPi)
+            _domain.add(*TMPi,*P1i,*P2i);
+        midmul(R, Rmid, Rend,
+               TMP, TMP.begin(), TMP.end(),
+               Q, Qbeg, Qmid);
+
+        // Rtmp ← S2 = MP(P1+, Q1- X^(n%2) Q0)
+        TMP.resize(n1);
+        RepConstIterator Q0i = Qbeg, Q1i = Qmid;
+        TMPi = TMP.begin();
+        if (n0 == n1) _domain.sub(*TMPi++,*Q1i++,*Q0i++);
+        else          _domain.assign(*TMPi++,*Q1i++);
+        for (;(Q0i!=Qmid) && (Q1i!=Qend); ++Q0i, ++Q1i, ++TMPi)
+            _domain.sub(*TMPi,*Q1i,*Q0i);
+        Rtmp.resize(n1);
+        midmul(Rtmp, Rtmp.begin(), Rtmp.end(),
+               P, P1beg, P1plus,
+               TMP, TMP.begin(), TMP.end());
+
+        // R0 ← R0 - S2
+        RepConstIterator S2i = Rtmp.begin();
+        for (RepIterator R0i = Rbeg; (R0i!=Rmid)&&(S2i!=Rtmp.end()); ++R0i, ++S2i)
+            _domain.subin(*R0i, *S2i);
+        // R1 ← R1 + S2*
+        S2i = Rtmp.begin();
+        for (RepIterator R1i = Rmid; (R1i!=Rend)&&(S2i!=Rtmp.end()); ++R1i, ++S2i)
+            _domain.addin(*R1i, *S2i);
+
+        return R;
+    }
+
 
 }
 #endif // __GIVARO_poly1_mid_INL

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,6 +37,7 @@ BASIC_TESTS =               \
 		test-trunc          \
 		test-matrix         \
 		test-poly           \
+		test-midmul         \
 		test-crt            \
 		test-geom           \
 		test-integer        \
@@ -116,6 +117,7 @@ test_modsqroot_SOURCES= test-modsqroot.C
 test_brillhart_SOURCES= test-brillhart.C
 test_trunc_SOURCES    = test-trunc.C
 test_poly_SOURCES    = test-poly.C
+test_midmul_SOURCES    = test-midmul.C
 test_matrix_SOURCES    = test-matrix.C
 test_crt_SOURCES      = test-crt.C
 test_geom_SOURCES     = test-geom.C

--- a/tests/test-midmul.C
+++ b/tests/test-midmul.C
@@ -15,57 +15,169 @@ using namespace Givaro;
 #define POLY POLYS::Element
 
 bool testMP(POLYS PD, POLY P, POLY Q, POLY R) {
-    POLY PQ;
-    PD.stdmul(PQ, P, Q);
     size_t sP = P.size(), sQ = Q.size(), sR = R.size();
     size_t m = sP-sQ+1;
+    POLY PQ;
+    PD.init(PQ, Degree(sP+sQ-2));
+    PD.stdmul(PQ, P, Q);
     Modular<int32_t>::Element r, pq;
-    if (sR != m) return false;
-    for (size_t i = 0; i < sR; i++)
+    if (sR > m) return false;
+    size_t i = 0;
+    for (; i < sR; i++)
         if (PD.getEntry(r,i,R) != PD.getEntry(pq,i+sQ-1,PQ))
+            return false;
+    for (; i < m; i++)
+        if (PD.getEntry(pq,i+sQ-1,PQ) != 0)
             return false;
     return true;
 }
 
 int main(int argc, char ** argv) {
     // argv[1] : modulo
-    // argv[2] : value of m
-    // argv[3] : value of n
+    // argv[2] : value of s1 (smaller)
+    // argv[3] : value of s2 (larger)
     // argv[4] : seed
 
     Modular<int32_t>::Residu_t MOD = (argc>1 ? (Modular<int32_t>::Residu_t) atoi(argv[1]) : 101);
-    size_t m = (argc>2 ? (size_t)atoi(argv[2]) : 100);
-    size_t n = (argc>3 ? (size_t)atoi(argv[3]) : 100);
-
+    size_t s1 = (argc>2 ? (size_t)atoi(argv[2]) : 100);
+    size_t s2 = (argc>3 ? (size_t)atoi(argv[3]) : s1*3/2);
     size_t seed = (argc>4?(size_t)atoi(argv[4]):(size_t)BaseTimer::seed());
+
 #ifdef __GIVARO_DEBUG
-    std::cerr << "seed: " << seed << std::endl;
+    std::cerr << "./test-midmul " << MOD << " " << s1 << " " << s2 << " " << seed << std::endl;
 #endif
+
     GivRandom generator(seed);
 
     Modular<int32_t> F(MOD);
     POLYS PD(F, Indeter("X"));
 
+    size_t m, n;
     POLY P, Q, R;
-    PD.random(generator,P,Degree(m+n));
-    PD.random(generator,Q,Degree(n-1));
     bool success, pass =true;
 
+    // Balanced case
 
+    m = s1; n = s1;
+    PD.random(generator,P,Degree(m+n-2));
+    PD.random(generator,Q,Degree(n-1));
 
-    // Standard middle product
+        // Standard middle product
 
-    PD.stdmidmul(R, P, Q);
-    pass &= (success = testMP(PD, P, Q, R));
+        PD.stdmidmul(R, P, Q);
+        pass &= (success = testMP(PD, P, Q, R));
 
-    if (! success) {
-        std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
-        PD.write(PD.write(PD.write(
-            std::cerr << "MP((", P) << "), (", Q) << ") = ", R) << ");" << std::endl;
-    } else
-        std::clog << "[stdMidMul] : " << GIV_PASSED_MSG << std::endl;
+        if (! success) {
+            std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+            PD.write(PD.write(PD.write(
+                std::cerr << "StdBalMP(P,Q) = R with" << std::endl
+                          << "P = ", P) << std::endl
+                          << "Q = ", Q) << std::endl
+                          << "R = ", R) << std::endl;
+        } else
+            std::clog << "[BalStdMidMul] : " << GIV_PASSED_MSG << std::endl;
 
+        // Karatsuba balanced middle product
 
+        PD.karamidmul(R, P, Q);
+        pass &= (success = testMP(PD, P, Q, R));
+
+        if (! success) {
+            std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+            PD.write(PD.write(PD.write(
+                std::cerr << "KaraMP(P,Q) = R with" << std::endl
+                          << "P = ", P) << std::endl
+                          << "Q = ", Q) << std::endl
+                          << "R = ", R) << std::endl;
+        } else
+            std::clog << "[BalKaraMidMul] : " << GIV_PASSED_MSG << std::endl;
+
+        // Dynamic dispatch
+
+        PD.midmul(R, P, Q);
+        pass &= (success = testMP(PD, P, Q, R));
+
+        if (! success) {
+            std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+            PD.write(PD.write(PD.write(
+                std::cerr << "BalMP(P,Q) = R with" << std::endl
+                          << "P = ", P) << std::endl
+                          << "Q = ", Q) << std::endl
+                          << "R = ", R) << std::endl;
+        } else
+            std::clog << "[BalMidMul] : " << GIV_PASSED_MSG << std::endl;
+
+    // Unbalanced case 1: m < n
+
+    m = s1; n = s2;
+    PD.random(generator,P,Degree(m+n-2));
+    PD.random(generator,Q,Degree(n-1));
+
+        // Standard middle product
+
+        PD.stdmidmul(R, P, Q);
+        pass &= (success = testMP(PD, P, Q, R));
+
+        if (! success) {
+            std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+            PD.write(PD.write(PD.write(
+                std::cerr << "UnbalStdMP1(P,Q) = R with" << std::endl
+                          << "P = ", P) << std::endl
+                          << "Q = ", Q) << std::endl
+                          << "R = ", R) << std::endl;
+        } else
+            std::clog << "[UnbalStdMidMul1] : " << GIV_PASSED_MSG << std::endl;
+
+        // Dynamic dispatch
+
+        PD.midmul(R, P, Q);
+        pass &= (success = testMP(PD, P, Q, R));
+
+        if (! success) {
+            std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+            PD.write(PD.write(PD.write(
+                std::cerr << "UnbalMP1(P,Q) = R with" << std::endl
+                          << "P = ", P) << std::endl
+                          << "Q = ", Q) << std::endl
+                          << "R = ", R) << std::endl;
+        } else
+            std::clog << "[UnbalMidMul1] : " << GIV_PASSED_MSG << std::endl;
+
+    // Unbalanced case 2: m > n
+
+    m = s2; n = s1;
+    PD.random(generator,P,Degree(m+n-2));
+    PD.random(generator,Q,Degree(n-1));
+
+        // Standard middle product
+
+        PD.stdmidmul(R, P, Q);
+        pass &= (success = testMP(PD, P, Q, R));
+
+        if (! success) {
+            std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+            PD.write(PD.write(PD.write(
+                std::cerr << "UnbalStdMP2(P,Q) = R with" << std::endl
+                          << "P = ", P) << std::endl
+                          << "Q = ", Q) << std::endl
+                          << "R = ", R) << std::endl;
+        } else
+            std::clog << "[UnbalStdMidMul2] : " << GIV_PASSED_MSG << std::endl;
+
+        // Dynamic dispatch
+
+        PD.midmul(R, P, Q);
+        pass &= (success = testMP(PD, P, Q, R));
+
+        if (! success) {
+            std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+            PD.write(PD.write(PD.write(
+                std::cerr << "UnbalMP2(P,Q) = R with" << std::endl
+                          << "P = ", P) << std::endl
+                          << "Q = ", Q) << std::endl
+                          << "R = ", R) << std::endl;
+        } else
+            std::clog << "[UnbalMidMul2] : " << GIV_PASSED_MSG << std::endl;
 
     return (! pass);
 }

--- a/tests/test-midmul.C
+++ b/tests/test-midmul.C
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <givaro/givrandom.h>
+#include <givaro/givtimer.h>
+#include <givaro/modular.h>
+#include <givaro/givpoly1.h>
+#include <givaro/givpower.h>
+#include <givaro/givquotientdomain.h>
+
+using namespace Givaro;
+
+#define GIV_PASSED_MSG "\033[1;32mPASSED.\033[0m"
+#define GIV_ERROR_MSG "\033[1;31m****** ERROR ******\033[0m "
+
+#define POLYS Poly1Dom< Modular<int32_t>, Dense >
+#define POLY POLYS::Element
+
+bool testMP(POLYS PD, POLY P, POLY Q, POLY R) {
+    POLY PQ;
+    PD.stdmul(PQ, P, Q);
+    size_t sP = P.size(), sQ = Q.size(), sR = R.size();
+    size_t m = sP-sQ+1;
+    Modular<int32_t>::Element r, pq;
+    if (sR != m) return false;
+    for (size_t i = 0; i < sR; i++)
+        if (PD.getEntry(r,i,R) != PD.getEntry(pq,i+sQ-1,PQ))
+            return false;
+    return true;
+}
+
+int main(int argc, char ** argv) {
+    // argv[1] : modulo
+    // argv[2] : value of m
+    // argv[3] : value of n
+    // argv[4] : seed
+
+    Modular<int32_t>::Residu_t MOD = (argc>1 ? (Modular<int32_t>::Residu_t) atoi(argv[1]) : 101);
+    size_t m = (argc>2 ? (size_t)atoi(argv[2]) : 100);
+    size_t n = (argc>3 ? (size_t)atoi(argv[3]) : 100);
+
+    size_t seed = (argc>4?(size_t)atoi(argv[4]):(size_t)BaseTimer::seed());
+#ifdef __GIVARO_DEBUG
+    std::cerr << "seed: " << seed << std::endl;
+#endif
+    GivRandom generator(seed);
+
+    Modular<int32_t> F(MOD);
+    POLYS PD(F, Indeter("X"));
+
+    POLY P, Q, R;
+    PD.random(generator,P,Degree(m+n));
+    PD.random(generator,Q,Degree(n-1));
+    bool success, pass =true;
+
+
+
+    // Standard middle product
+
+    PD.stdmidmul(R, P, Q);
+    pass &= (success = testMP(PD, P, Q, R));
+
+    if (! success) {
+        std::cerr << GIV_ERROR_MSG << seed << ':' << m << ',' << n << std::endl;
+        PD.write(PD.write(PD.write(
+            std::cerr << "MP((", P) << "), (", Q) << ") = ", R) << ");" << std::endl;
+    } else
+        std::clog << "[stdMidMul] : " << GIV_PASSED_MSG << std::endl;
+
+
+
+    return (! pass);
+}
+
+#undef POLY
+#undef POLYS
+
+/* -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+// vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s


### PR DESCRIPTION
- Implement (a generalized version of) the Polynomial Middle Product as defined in [Hanrot-Quercia-Zimmerman'04](https://doi.org/10.1007/s00200-003-0144-2): If P has size m+n-1 and Q has size n, MP(P,Q) is the size-m polynomial made of the central coefficients of the product P×Q.
- Three implementations:
  + Standard quadratic algorithm : `stdmidmul`;
  + Karatsuba algorithm for the balanced case (m=n): `karamidmul`;
  + A dispatch algorithm for the general case that that either calls the quadratic algorithm for small sizes or Karatsuba's algorithm for larger sizes: `midmul`. (In particular, in the unbalanced case (m≠n), several calls are made to Karatsuba's algorithm with balanced inputs.)

The aim is to use this Middle Product in Newton iteration introduced in #206. This will be made in a future PR.