### PR TITLE
Add missing #include <cstdint> for (u)int64_t

### DIFF
--- a/src/library/poly1/givdegree.h
+++ b/src/library/poly1/givdegree.h
@@ -19,6 +19,8 @@
 #ifndef __GIVARO_poly1degree_H
 #define __GIVARO_poly1degree_H
 
+#include <cstdint>
+
 #include <iostream>
 
 namespace Givaro {


### PR DESCRIPTION
Fixes failure to compile on GCC 13.