### PR TITLE
configure.ac: fix a bashism

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,7 +121,7 @@ AS_ECHO([---------------------------------------])
 
 # Look for GMP and add flags if necessary
 GIV_CHECK_GMP(40000)
-REQUIRED_FLAGS+=" ${GMP_CFLAGS}"
+REQUIRED_FLAGS="${REQUIRED_FLAGS} ${GMP_CFLAGS}"
 
 GIV_DOC
 


### PR DESCRIPTION
There's one instance of `VAR+=" value"` in the configure script, but that only works in bash. With dash, for example, it results in

> checking whether gmp version is at least 40000... yes
> ./configure: 17953: REQUIRED_FLAGS+= : not found

We change it to a `VAR="${VAR} value"` instead.