### PR TITLE
Fix build using GCC 15

### DIFF
--- a/src/kernel/recint/rfiddling.h
+++ b/src/kernel/recint/rfiddling.h
@@ -167,7 +167,7 @@ namespace RecInt
     template <size_t K>
     inline rint<K> rint<K>::maxFFLAS() {
         rint<K> max;
-        set_highest_bit(max.Low.Value);
+        set_highest_bit(max.Value.Low.Value);
         return max;
     }
 


### PR DESCRIPTION
max is an rint, which doesn't have a "Low" member.  But max.Value, which is an ruint, does.

Closes: #232