### PR TITLE
Remove wrong version number in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,5 @@ docs_dev:docs/givaro-dev-html/index.html
 docs/givaro-dev-html/index.html:
 	(cd docs; ${MAKE} docs_dev)
 
-VERSION=4.2.1
-
 git:
 	git commit -a; git pull; git push

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,7 @@ docs_dev:docs/givaro-dev-html/index.html
 docs/givaro-dev-html/index.html:
 	(cd docs; ${MAKE} docs_dev)
 
-VERSION=4.2.1alpha0
+VERSION=4.2.1
 
 git:
 	git commit -a; git pull; git push


### PR DESCRIPTION
As of the 4.2.1 release, Makefile.am still had `VERSION=4.2.1alpha0`.

This resulted in https://github.com/linbox-team/givaro/issues/235 and the various issues noted therein.

Given that https://github.com/linbox-team/givaro/releases/tag/v4.2.1 has already been tagged, maybe it’s easier to update this value again and re-release as 4.2.2.