### PR TITLE
Look for gmp++ headers in src/kernel

### DIFF
--- a/src/kernel/gmp++/Makefile.am
+++ b/src/kernel/gmp++/Makefile.am
@@ -9,8 +9,10 @@ AM_CPPFLAGS=-I$(top_builddir) ${GMP_VERSION}
 pkgincludesubdir=$(includedir)/gmp++
 
 AM_CXXFLAGS=$(GIVARO_CXXFLAGS)
-AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/memory -I$(top_builddir)/src/kernel/system -I$(top_builddir)/src/kernel/recint
-
+AM_CPPFLAGS+= -I$(top_builddir)/src/kernel/memory \
+	-I$(top_builddir)/src/kernel/system       \
+	-I$(top_builddir)/src/kernel/recint       \
+	-I$(top_builddir)/src/kernel
 
 noinst_LTLIBRARIES=libgmppp.la
 


### PR DESCRIPTION
Several files in src/kernel/gmp++ look for headers in the same directory, but with the "gmp++/" prefix specified.  We ensure that we look in the parent directory so we can find them.

I ran into this issue trying to build givaro in OpenIndiana.