### PR TITLE
Fix formatting of user-defined literal operators in udl.h

### DIFF
--- a/src/kernel/system/udl.h
+++ b/src/kernel/system/udl.h
@@ -15,42 +15,42 @@
  *  Allows cross-platform literals with compile-time cast.
  */
 
-constexpr uint64_t operator"" _ui64(unsigned long long x)
+constexpr uint64_t operator""_ui64(unsigned long long x)
 {
     return static_cast<uint64_t>(x);
 }
 
-constexpr uint32_t operator"" _ui32(unsigned long long x)
+constexpr uint32_t operator""_ui32(unsigned long long x)
 {
     return static_cast<uint32_t>(x);
 }
 
-constexpr uint16_t operator"" _ui16(unsigned long long x)
+constexpr uint16_t operator""_ui16(unsigned long long x)
 {
     return static_cast<uint16_t>(x);
 }
 
-constexpr uint8_t operator"" _ui8(unsigned long long x)
+constexpr uint8_t operator""_ui8(unsigned long long x)
 {
     return static_cast<uint8_t>(x);
 }
 
-constexpr int64_t operator"" _i64(unsigned long long x)
+constexpr int64_t operator""_i64(unsigned long long x)
 {
     return static_cast<int64_t>(x);
 }
 
-constexpr int32_t operator"" _i32(unsigned long long x)
+constexpr int32_t operator""_i32(unsigned long long x)
 {
     return static_cast<int32_t>(x);
 }
 
-constexpr int16_t operator"" _i16(unsigned long long x)
+constexpr int16_t operator""_i16(unsigned long long x)
 {
     return static_cast<int16_t>(x);
 }
 
-constexpr int8_t operator"" _i8(unsigned long long x)
+constexpr int8_t operator""_i8(unsigned long long x)
 {
     return static_cast<int8_t>(x);
 }


### PR DESCRIPTION
some minor fix for format

Fix
```
libtool: compile:  /opt/homebrew/opt/llvm/bin/clang++ -DHAVE_CONFIG_H -I. -I../../../../src/kernel/gmp++ -I../../.. -I../../.. -I../../../src/kernel/memory -I../../../src/kernel/system -I../../../src/kernel/recint -I../../../src/kernel -I/opt/homebrew/opt/gmp/include -O2 -march=native -Wall -DNDEBUG -UDEBUG -stdlib=libc++ -MT gmp++_int_mod.lo -MD -MP -MF .deps/gmp++_int_mod.Tpo -c ../../../../src/kernel/gmp++/gmp++_int_mod.C -o gmp++_int_mod.o >/dev/null 2>&1
../../../src/kernel/system/givaro/udl.h:23:31: warning: identifier '_ui32' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   23 | constexpr uint32_t operator"" _ui32(unsigned long long x)
      |                    ~~~~~~~~~~~^~~~~
      |                    operator""_ui32
libtool: compile:  /opt/homebrew/opt/llvm/bin/clang++ -DHAVE_CONFIG_H -I. -I../../../../src/kernel/gmp++ -I../../.. -I../../.. -I../../../src/kernel/memory -I../../../src/kernel/system -I../../../src/kernel/recint -I../../../src/kernel -I/opt/homebrew/opt/gmp/include -O2 -march=native -Wall -DNDEBUG -UDEBUG -stdlib=libc++ -MT gmp++_int_div.lo -MD -MP -MF .deps/gmp++_int_div.Tpo -c ../../../../src/kernel/gmp++/gmp++_int_div.C -o gmp++_int_div.o >/dev/null 2>&1
../../../src/kernel/system/givaro/udl.h:28:31: warning: identifier '_ui16' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   28 | constexpr uint16_t operator"" _ui16(unsigned long long x)
      |                    ~~~~~~~~~~~^~~~~
      |                    operator""_ui16
../../../src/kernel/system/givaro/udl.h:33:30: warning: identifier '_ui8' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   33 | constexpr uint8_t operator"" _ui8(unsigned long long x)
      |                   ~~~~~~~~~~~^~~~
      |                   operator""_ui8
../../../src/kernel/system/givaro/udl.h:38:30: warning: identifier '_i64' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   38 | constexpr int64_t operator"" _i64(unsigned long long x)
      |                   ~~~~~~~~~~~^~~~
      |                   operator""_i64
../../../src/kernel/system/givaro/udl.h:43:30: warning: identifier '_i32' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   43 | constexpr int32_t operator"" _i32(unsigned long long x)
      |                   ~~~~~~~~~~~^~~~
      |                   operator""_i32
../../../src/kernel/system/givaro/udl.h:48:30: warning: identifier '_i16' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   48 | constexpr int16_t operator"" _i16(unsigned long long x)
      |                   ~~~~~~~~~~~^~~~
      |                   operator""_i16
../../../src/kernel/system/givaro/udl.h:53:29: warning: identifier '_i8' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   53 | constexpr int8_t operator"" _i8(unsigned long long x)
      |                  ~~~~~~~~~~~^~~
      |                  operator""_i8
In file included from ../../../../src/kernel/gmp++/gmp++_int_div.C:19:
In file included from ./gmp++/gmp++.h:57:
In file included from ./gmp++/gmp++_int.h:1803:
In file included from ./gmp++/gmp++_int_rand.inl:21:
In file included from ../../../src/kernel/system/givaro/givrandom.h:22:
../../../src/kernel/system/givaro/udl.h:18:31: warning: identifier '_ui64' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   18 | constexpr uint64_t operator"" _ui64(unsigned long long x)
      |                    ~~~~~~~~~~~^~~~~
      |                    operator""_ui64
../../../src/kernel/system/givaro/udl.h:23:31: warning: identifier '_ui32' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   23 | constexpr uint32_t operator"" _ui32(unsigned long long x)
      |                    ~~~~~~~~~~~^~~~~
      |                    operator""_ui32
../../../src/kernel/system/givaro/udl.h:28:31: warning: identifier '_ui16' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
   28 | constexpr uint16_t operator"" _ui16(unsigned long long x)
      |                    ~~~~~~~~~~~^~~~~
      |                    operator""_ui16
../../../src/kernel/system/givaro/udl.h:33:30: warning: identifier '_ui8' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
mv -f .deps/gmp++_int_lib.Tpo .deps/gmp++_int_lib.Plo
   33 | constexpr uint8_t operator"" _ui8(unsigned long long x)
      |                   ~~~~~~~~~~~^~~~
      |                   operator""_ui8
```